### PR TITLE
meshchat-29

### DIFF
--- a/src/channel_view.rs
+++ b/src/channel_view.rs
@@ -144,6 +144,11 @@ impl ChannelView {
     }
 
     /// Return an Element that displays a day separator
+    /// If in the same week, then just the day name "Friday"
+    /// If in a previous week, of the same year, then "Friday, Jul 8"
+    /// If in a previous year, then "Friday, Jul 8, 2021"
+    ///
+    /// Meaning of format strings used
     /// "%Y" - Year . e.g. "2021"
     /// "%b" - Three letter month name e.g. "Jul"
     /// "%e" - space padded date e.g. " 8" for the 8th day of the month

--- a/src/styles.rs
+++ b/src/styles.rs
@@ -147,6 +147,12 @@ const MESSAGE_BORDER: Border = Border {
     color: Color::WHITE,
 };
 
+const DAY_SEPARATOR_BORDER: Border = Border {
+    radius: RADIUS_12, // rounded corners
+    width: 2.0,
+    color: Color::TRANSPARENT,
+};
+
 // TODO make a closure that reacts to the theme
 pub const MESSAGE_TEXT_STYLE: text::Style = text::Style {
     color: Some(Color::WHITE),
@@ -166,7 +172,7 @@ pub const MY_MESSAGE_BUBBLE_STYLE: Style = Style {
 pub const DAY_SEPARATOR_STYLE: Style = Style {
     text_color: Some(Color::WHITE),
     background: Some(Background::Color(Color::from_rgba(0.0, 0.0, 0.0, 1.0))),
-    border: MESSAGE_BORDER,
+    border: DAY_SEPARATOR_BORDER,
     shadow: NO_SHADOW,
 };
 


### PR DESCRIPTION
Fixes #29
Implements the display of a day separator in the chat messages view, separating messages into chunks by day, with different formatting depending on how far in the past