### PR TITLE
feat: TCP support with feature gating

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -41,6 +41,20 @@ jobs:
           command: clippy
           args: --tests --no-deps --all-features --all-targets
 
+  all-feature-combinations:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: sudo apt install libdbus-1-dev pkg-config
+      - name: Install cargo-all-features
+        run: cargo install cargo-all-features
+      - name: Check all feature combinations
+        run: cargo check-all-features
+
   todo-check:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1238,6 +1238,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1783,7 +1794,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2192,6 +2203,16 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "if-addrs"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b2eeee38fef3aa9b4cc5f1beea8a2444fc00e7377cafae396de3f5c2065e24"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2736,6 +2757,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "mdns-sd"
+version = "0.13.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328f4e1041f7cfeb3affccb814ddbe2f004856a2ce769c8bf22080d74c5204c6"
+dependencies = [
+ "fastrand",
+ "flume",
+ "if-addrs",
+ "mio",
+ "socket2 0.5.10",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2774,6 +2808,7 @@ dependencies = [
  "iced_aw",
  "iced_fontello",
  "lyon_algorithms",
+ "mdns-sd",
  "meshcore-rs",
  "meshtastic",
  "ringmap",
@@ -3736,7 +3771,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3774,7 +3809,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4596,6 +4631,16 @@ dependencies = [
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
@@ -4633,6 +4678,15 @@ dependencies = [
  "web-sys",
  "windows-sys 0.61.2",
  "x11rb",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]
@@ -4954,7 +5008,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,8 @@ iced_aw = { version = "0.14", default-features = false, features = ["menu"] }
 btleplug = { version = "0.11.8", default-features = false }
 emojis = { version = "0.8.2", default-features = false }
 uuid = { version = "1.23.1", default-features = false, features = ["v4"] }
+# mDNS-SD discovery of Meshtastic TCP devices on the LAN (`_meshtastic._tcp.local.`)
+mdns-sd = { version = "0.13", default-features = false, features = ["async"] }
 
 # Optional dependencies
 meshtastic = { version = "0.1.8", default-features = false, features = ["serde", "tokio", "bluetooth-le"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,11 @@ license = "GPL-3.0"
 include = ["src", "assets", "build.rs", "README.md", "LICENSE", "!**/.DS_Store"]
 
 [features]
-default = ["meshtastic", "meshcore"]
+default = ["meshtastic", "meshcore", "bluetooth", "tcp"]
 meshcore = ["dep:meshcore-rs"]
 meshtastic = ["dep:meshtastic"]
+bluetooth = ["dep:btleplug"]
+tcp = ["dep:mdns-sd"]
 debug = ["iced/debug", "dep:tracing", "dep:tracing-subscriber"] # use "... --features "debug" to enable this for Iced
 hot = ["iced/hot"]
 # Allow the feature to check for app updates to be disabled by people building for distribution channels that take care of updates themselves
@@ -43,15 +45,15 @@ futures-channel = { version = "0.3.32", default-features = false }
 chrono = { version = "0.4.44", default-features = false, features = ["clock"] }
 webbrowser = { version = "1.2", default-features = false }
 iced_aw = { version = "0.14", default-features = false, features = ["menu"] }
-btleplug = { version = "0.11.8", default-features = false }
 emojis = { version = "0.8.2", default-features = false }
 uuid = { version = "1.23.1", default-features = false, features = ["v4"] }
-# mDNS-SD discovery of Meshtastic TCP devices on the LAN (`_meshtastic._tcp.local.`)
-mdns-sd = { version = "0.13", default-features = false, features = ["async"] }
 
 # Optional dependencies
 meshtastic = { version = "0.1.8", default-features = false, features = ["serde", "tokio", "bluetooth-le"], optional = true }
 meshcore-rs = { version = "0.1.9", default-features = false, features = ["ble"], optional = true }
+btleplug = { version = "0.11.8", default-features = false, optional = true }
+# mDNS-SD discovery of Meshtastic TCP devices on the LAN (`_meshtastic._tcp.local.`)
+mdns-sd = { version = "0.13", default-features = false, features = ["async"], optional = true }
 # Self-update requiers us to chose the http backend to use
 self_update = { version = "0.44.0", default-features = false, features = ["reqwest"], optional = true }
 tracing = { version = "0.1", optional = true }
@@ -91,10 +93,13 @@ panic = "deny"
 [package.metadata.cargo-all-features]
 # Exclude certain features from the build matrix
 denylist = ["hot", "debug"]
-# Skip combinations that don't include at least one radio protocol
+# Skip combinations that don't include at least one radio protocol or one transport
 skip_feature_sets = [
     [], # no features
     ["auto-update"], # only auto-update without radio support
+    ["bluetooth"], # transport without radio
+    ["tcp"], # transport without radio
+    ["bluetooth", "tcp"], # transports without radio
 ]
 
 # For cargo packager tool

--- a/src/config.rs
+++ b/src/config.rs
@@ -403,6 +403,7 @@ pub fn load_config() -> Task<Message> {
 #[cfg(test)]
 mod tests {
     use crate::config::{Config, HistoryLength, ONE_DAY_IN_SECONDS, load, save};
+    #[cfg(feature = "bluetooth")]
     use btleplug::api::BDAddr;
     use std::collections::{HashMap, HashSet};
     use std::io;
@@ -451,7 +452,7 @@ mod tests {
         assert_default(returned);
     }
 
-    #[cfg(feature = "meshtastic")]
+    #[cfg(all(feature = "meshtastic", feature = "bluetooth"))]
     #[tokio::test]
     async fn mac_address_saved() {
         let config = Config {

--- a/src/device.rs
+++ b/src/device.rs
@@ -66,36 +66,76 @@ impl Default for ConnectionState {
     }
 }
 
-/// Due to cross-platform differences, one cannot reliably be used. But one of the two must exist
-/// so that we can connect to it later. Discovery will try to get both (depending on the platform).
-/// But subscription will try to connect using the one it knows that works by platform
-#[derive(Default, Clone, PartialEq, Eq, Hash, Debug)]
-pub struct DeviceIdentifier {
-    pub(crate) name: Option<String>,
-    pub(crate) mac: Option<BDAddr>,
+/// How a device is reached. BLE keeps its existing fields; TCP records the resolved
+/// host/port and any human-readable name from mDNS.
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub enum DeviceIdentifier {
+    Ble {
+        name: Option<String>,
+        mac: Option<BDAddr>,
+    },
+    Tcp {
+        name: Option<String>,
+        host: String,
+        port: u16,
+    },
+}
+
+impl Default for DeviceIdentifier {
+    fn default() -> Self {
+        DeviceIdentifier::Ble {
+            name: None,
+            mac: None,
+        }
+    }
 }
 
 impl DeviceIdentifier {
     pub fn name(&self) -> String {
-        self.name.clone().unwrap_or("Unknown".to_string())
+        match self {
+            DeviceIdentifier::Ble { name, .. } | DeviceIdentifier::Tcp { name, .. } => {
+                name.clone().unwrap_or_else(|| "Unknown".to_string())
+            }
+        }
     }
 
     pub fn mac(&self) -> String {
-        self.mac
-            .map(|mac| mac.to_string())
-            .unwrap_or("Unknown".to_string())
+        match self {
+            DeviceIdentifier::Ble { mac, .. } => mac
+                .map(|mac| mac.to_string())
+                .unwrap_or_else(|| "Unknown".to_string()),
+            DeviceIdentifier::Tcp { .. } => "Unknown".to_string(),
+        }
     }
 }
 
+const TCP_SCHEME: &str = "tcp://";
+
 impl From<&str> for DeviceIdentifier {
     fn from(value: &str) -> Self {
+        // Recognize a serialized TCP device: tcp://host:port[#name]
+        if let Some(rest) = value.strip_prefix(TCP_SCHEME) {
+            let (addr, name) = match rest.split_once('#') {
+                Some((addr, name)) => (addr, Some(name.to_string())),
+                None => (rest, None),
+            };
+            if let Some((host, port)) = addr.rsplit_once(':')
+                && let Ok(port) = port.parse::<u16>()
+            {
+                return DeviceIdentifier::Tcp {
+                    name,
+                    host: host.to_string(),
+                    port,
+                };
+            }
+        }
         if let Ok(mac) = BDAddr::from_str_delim(value) {
-            DeviceIdentifier {
+            DeviceIdentifier::Ble {
                 name: None,
                 mac: Some(mac),
             }
         } else {
-            DeviceIdentifier {
+            DeviceIdentifier::Ble {
                 name: Some(value.to_string()),
                 mac: None,
             }
@@ -105,40 +145,32 @@ impl From<&str> for DeviceIdentifier {
 
 impl From<String> for DeviceIdentifier {
     fn from(value: String) -> Self {
-        if let Ok(mac) = BDAddr::from_str_delim(&value) {
-            DeviceIdentifier {
-                name: None,
-                mac: Some(mac),
-            }
-        } else {
-            DeviceIdentifier {
-                name: Some(value),
-                mac: None,
-            }
-        }
+        DeviceIdentifier::from(value.as_str())
     }
 }
 
 impl From<DeviceIdentifier> for String {
     fn from(value: DeviceIdentifier) -> Self {
-        if let Some(name) = value.name {
-            name
-        } else if let Some(mac) = value.mac {
-            mac.to_string()
-        } else {
-            "Unknown".to_string()
-        }
+        String::from(&value)
     }
 }
 
 impl From<&DeviceIdentifier> for String {
     fn from(value: &DeviceIdentifier) -> Self {
-        if let Some(name) = &value.name {
-            name.to_string()
-        } else if let Some(mac) = value.mac {
-            mac.to_string()
-        } else {
-            "Unknown".to_string()
+        match value {
+            DeviceIdentifier::Ble { name, mac } => {
+                if let Some(name) = name {
+                    name.clone()
+                } else if let Some(mac) = mac {
+                    mac.to_string()
+                } else {
+                    "Unknown".to_string()
+                }
+            }
+            DeviceIdentifier::Tcp { name, host, port } => match name {
+                Some(name) => format!("{TCP_SCHEME}{host}:{port}#{name}"),
+                None => format!("{TCP_SCHEME}{host}:{port}"),
+            },
         }
     }
 }

--- a/src/device.rs
+++ b/src/device.rs
@@ -38,6 +38,7 @@ use crate::styles::{
 };
 use crate::timestamp::TimeStamp;
 use crate::widgets::battery::{Battery, BatteryState};
+#[cfg(feature = "bluetooth")]
 use btleplug::api::BDAddr;
 use iced::widget::scrollable::Scrollbar;
 use iced::widget::{
@@ -70,10 +71,12 @@ impl Default for ConnectionState {
 /// host/port and any human-readable name from mDNS.
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub enum DeviceIdentifier {
+    #[cfg(feature = "bluetooth")]
     Ble {
         name: Option<String>,
         mac: Option<BDAddr>,
     },
+    #[cfg(feature = "tcp")]
     Tcp {
         name: Option<String>,
         host: String,
@@ -83,9 +86,20 @@ pub enum DeviceIdentifier {
 
 impl Default for DeviceIdentifier {
     fn default() -> Self {
-        DeviceIdentifier::Ble {
-            name: None,
-            mac: None,
+        #[cfg(feature = "bluetooth")]
+        {
+            return DeviceIdentifier::Ble {
+                name: None,
+                mac: None,
+            };
+        }
+        #[cfg(all(feature = "tcp", not(feature = "bluetooth")))]
+        {
+            DeviceIdentifier::Tcp {
+                name: None,
+                host: String::new(),
+                port: 0,
+            }
         }
     }
 }
@@ -93,51 +107,71 @@ impl Default for DeviceIdentifier {
 impl DeviceIdentifier {
     pub fn name(&self) -> String {
         match self {
-            DeviceIdentifier::Ble { name, .. } | DeviceIdentifier::Tcp { name, .. } => {
+            #[cfg(feature = "bluetooth")]
+            DeviceIdentifier::Ble { name, .. } => {
                 name.clone().unwrap_or_else(|| "Unknown".to_string())
+            }
+            #[cfg(feature = "tcp")]
+            DeviceIdentifier::Tcp { name, host, port } => {
+                name.clone().unwrap_or_else(|| format!("{host}:{port}"))
             }
         }
     }
 
-    pub fn mac(&self) -> String {
+    #[cfg(feature = "bluetooth")]
+    pub fn mac(&self) -> Option<String> {
         match self {
-            DeviceIdentifier::Ble { mac, .. } => mac
-                .map(|mac| mac.to_string())
-                .unwrap_or_else(|| "Unknown".to_string()),
-            DeviceIdentifier::Tcp { .. } => "Unknown".to_string(),
+            DeviceIdentifier::Ble { mac, .. } => mac.map(|mac| mac.to_string()),
+            #[cfg(feature = "tcp")]
+            DeviceIdentifier::Tcp { .. } => None,
         }
     }
 }
 
+#[cfg(feature = "tcp")]
 const TCP_SCHEME: &str = "tcp://";
 
 impl From<&str> for DeviceIdentifier {
     fn from(value: &str) -> Self {
-        // Recognize a serialized TCP device: tcp://host:port[#name]
-        if let Some(rest) = value.strip_prefix(TCP_SCHEME) {
-            let (addr, name) = match rest.split_once('#') {
-                Some((addr, name)) => (addr, Some(name.to_string())),
-                None => (rest, None),
-            };
-            if let Some((host, port)) = addr.rsplit_once(':')
-                && let Ok(port) = port.parse::<u16>()
-            {
-                return DeviceIdentifier::Tcp {
-                    name,
-                    host: host.to_string(),
-                    port,
+        #[cfg(feature = "tcp")]
+        {
+            if let Some(rest) = value.strip_prefix(TCP_SCHEME) {
+                let (addr, name) = match rest.split_once('#') {
+                    Some((addr, name)) => (addr, Some(name.to_string())),
+                    None => (rest, None),
                 };
+                if let Some((host, port_str)) = addr.rsplit_once(':') {
+                    if let Ok(port) = port_str.parse::<u16>() {
+                        if !host.trim().is_empty() && port > 0 {
+                            return DeviceIdentifier::Tcp {
+                                name,
+                                host: host.to_string(),
+                                port,
+                            };
+                        }
+                    }
+                }
             }
         }
-        if let Ok(mac) = BDAddr::from_str_delim(value) {
-            DeviceIdentifier::Ble {
-                name: None,
-                mac: Some(mac),
+        #[cfg(feature = "bluetooth")]
+        {
+            if let Ok(mac) = BDAddr::from_str_delim(value) {
+                return DeviceIdentifier::Ble {
+                    name: None,
+                    mac: Some(mac),
+                };
             }
-        } else {
-            DeviceIdentifier::Ble {
+            return DeviceIdentifier::Ble {
                 name: Some(value.to_string()),
                 mac: None,
+            };
+        }
+        #[cfg(all(feature = "tcp", not(feature = "bluetooth")))]
+        {
+            DeviceIdentifier::Tcp {
+                name: Some(value.to_string()),
+                host: String::new(),
+                port: 0,
             }
         }
     }
@@ -158,6 +192,7 @@ impl From<DeviceIdentifier> for String {
 impl From<&DeviceIdentifier> for String {
     fn from(value: &DeviceIdentifier) -> Self {
         match value {
+            #[cfg(feature = "bluetooth")]
             DeviceIdentifier::Ble { name, mac } => {
                 if let Some(name) = name {
                     name.clone()
@@ -167,10 +202,18 @@ impl From<&DeviceIdentifier> for String {
                     "Unknown".to_string()
                 }
             }
-            DeviceIdentifier::Tcp { name, host, port } => match name {
-                Some(name) => format!("{TCP_SCHEME}{host}:{port}#{name}"),
-                None => format!("{TCP_SCHEME}{host}:{port}"),
-            },
+            #[cfg(feature = "tcp")]
+            DeviceIdentifier::Tcp { name, host, port } => {
+                let endpoint = if host.contains(':') {
+                    format!("{TCP_SCHEME}[{host}]:{port}")
+                } else {
+                    format!("{TCP_SCHEME}{host}:{port}")
+                };
+                match name {
+                    Some(name) => format!("{endpoint}#{name}"),
+                    None => endpoint,
+                }
+            }
         }
     }
 }
@@ -2993,5 +3036,108 @@ mod tests {
         let _element = device_view.section_header("Test Section".into());
         let _element = device_view.section_header("Channels (5)".into());
         let _element = device_view.section_header("".into());
+    }
+
+    #[cfg(feature = "tcp")]
+    #[test]
+    fn test_tcp_identifier_parse() {
+        let id = DeviceIdentifier::from("tcp://192.168.1.100:4403");
+        assert!(
+            matches!(id, DeviceIdentifier::Tcp { name: None, ref host, port } if host == "192.168.1.100" && port == 4403)
+        );
+    }
+
+    #[cfg(feature = "tcp")]
+    #[test]
+    fn test_tcp_identifier_parse_with_name() {
+        let id = DeviceIdentifier::from("tcp://192.168.1.100:4403#MyMeshy");
+        assert!(
+            matches!(id, DeviceIdentifier::Tcp { ref name, ref host, port }
+            if name.as_deref() == Some("MyMeshy") && host == "192.168.1.100" && port == 4403)
+        );
+    }
+
+    #[cfg(feature = "tcp")]
+    #[test]
+    fn test_tcp_identifier_roundtrip() {
+        let original = "tcp://192.168.1.100:4403#MyMeshy";
+        let id = DeviceIdentifier::from(original);
+        let serialized: String = (&id).into();
+        assert_eq!(serialized, original);
+    }
+
+    #[cfg(feature = "tcp")]
+    #[test]
+    fn test_tcp_identifier_roundtrip_no_name() {
+        let original = "tcp://10.0.0.1:4403";
+        let id = DeviceIdentifier::from(original);
+        let serialized: String = (&id).into();
+        assert_eq!(serialized, original);
+    }
+
+    #[cfg(feature = "tcp")]
+    #[test]
+    fn test_tcp_name_fallback_shows_endpoint() {
+        let id = DeviceIdentifier::Tcp {
+            name: None,
+            host: "192.168.1.100".to_string(),
+            port: 4403,
+        };
+        assert_eq!(id.name(), "192.168.1.100:4403");
+    }
+
+    #[cfg(feature = "tcp")]
+    #[test]
+    fn test_tcp_name_shows_name_when_present() {
+        let id = DeviceIdentifier::Tcp {
+            name: Some("MyMeshy".to_string()),
+            host: "192.168.1.100".to_string(),
+            port: 4403,
+        };
+        assert_eq!(id.name(), "MyMeshy");
+    }
+
+    #[cfg(all(feature = "tcp", feature = "bluetooth"))]
+    #[test]
+    fn test_tcp_mac_returns_none() {
+        let id = DeviceIdentifier::Tcp {
+            name: None,
+            host: "192.168.1.100".to_string(),
+            port: 4403,
+        };
+        assert!(id.mac().is_none());
+    }
+
+    #[cfg(all(feature = "tcp", feature = "bluetooth"))]
+    #[test]
+    fn test_tcp_rejects_empty_host() {
+        let id = DeviceIdentifier::from("tcp://:4403");
+        assert!(matches!(id, DeviceIdentifier::Ble { .. }));
+    }
+
+    #[cfg(all(feature = "tcp", feature = "bluetooth"))]
+    #[test]
+    fn test_tcp_rejects_port_zero() {
+        let id = DeviceIdentifier::from("tcp://192.168.1.100:0");
+        assert!(matches!(id, DeviceIdentifier::Ble { .. }));
+    }
+
+    #[cfg(feature = "tcp")]
+    #[test]
+    fn test_tcp_ipv6_roundtrip() {
+        let id = DeviceIdentifier::Tcp {
+            name: None,
+            host: "fe80::1".to_string(),
+            port: 4403,
+        };
+        let serialized: String = (&id).into();
+        assert_eq!(serialized, "tcp://[fe80::1]:4403");
+    }
+
+    #[cfg(all(feature = "bluetooth", feature = "tcp"))]
+    #[test]
+    fn test_ble_name_not_misidentified_as_tcp() {
+        let id = DeviceIdentifier::from("MyDevice");
+        assert!(matches!(id, DeviceIdentifier::Ble { .. }));
     }
 }

--- a/src/device.rs
+++ b/src/device.rs
@@ -142,7 +142,8 @@ impl From<&str> for DeviceIdentifier {
                 };
                 if let Some((host, port_str)) = addr.rsplit_once(':') {
                     if let Ok(port) = port_str.parse::<u16>() {
-                        if !host.trim().is_empty() && port > 0 {
+                        let host = host.trim_start_matches('[').trim_end_matches(']');
+                        if !host.is_empty() && port > 0 {
                             return DeviceIdentifier::Tcp {
                                 name,
                                 host: host.to_string(),
@@ -3124,7 +3125,7 @@ mod tests {
 
     #[cfg(feature = "tcp")]
     #[test]
-    fn test_tcp_ipv6_roundtrip() {
+    fn test_tcp_ipv6_serialization() {
         let id = DeviceIdentifier::Tcp {
             name: None,
             host: "fe80::1".to_string(),
@@ -3132,6 +3133,18 @@ mod tests {
         };
         let serialized: String = (&id).into();
         assert_eq!(serialized, "tcp://[fe80::1]:4403");
+    }
+
+    #[cfg(feature = "tcp")]
+    #[test]
+    fn test_tcp_ipv6_parse_roundtrip() {
+        let original = "tcp://[fe80::1]:4403";
+        let id = DeviceIdentifier::from(original);
+        let serialized: String = (&id).into();
+        assert_eq!(
+            serialized, original,
+            "IPv6 address should roundtrip correctly"
+        );
     }
 
     #[cfg(all(feature = "bluetooth", feature = "tcp"))]

--- a/src/device_list.rs
+++ b/src/device_list.rs
@@ -247,9 +247,10 @@ impl DeviceList {
             device_row = device_row.push(icon);
             device_row = device_row.push(Space::new().width(8));
 
-            // Transport badge so the user can tell BLE devices apart from LAN/TCP devices.
             let (transport_label, transport_tip) = match device_identifier {
+                #[cfg(feature = "bluetooth")]
                 DeviceIdentifier::Ble { .. } => ("BT", "Connected via Bluetooth LE".to_string()),
+                #[cfg(feature = "tcp")]
                 DeviceIdentifier::Tcp { host, port, .. } => {
                     ("TCP", format!("Reachable over TCP at {host}:{port}"))
                 }
@@ -1333,7 +1334,7 @@ mod tests {
         #[cfg(feature = "meshcore")]
         let _ = view.update(MeshRadioFound(
             "meshcore_device".into(),
-            RadioType::Meshtastic,
+            RadioType::MeshCore,
         ));
 
         let config = Config::default();

--- a/src/device_list.rs
+++ b/src/device_list.rs
@@ -7,7 +7,7 @@ use crate::device::ConnectionState::{Connected, Connecting, Disconnected, Discon
 use crate::device::DeviceMessage::{ConnectRequest, DisconnectRequest};
 use crate::device::{ConnectionState, Device, DeviceIdentifier};
 use crate::device_list::DeviceListEvent::{
-    AliasInput, BLEMeshRadioFound, BLERadioLost, CriticalError, Error, Scanning, StartEditingAlias,
+    AliasInput, CriticalError, Error, MeshRadioFound, MeshRadioLost, Scanning, StartEditingAlias,
 };
 use crate::meshchat::View;
 use crate::styles::{button_chip_style, menu_button_style, text_input_style, tooltip_style};
@@ -48,8 +48,8 @@ pub enum RadioType {
 
 #[derive(Debug, Clone)]
 pub enum DeviceListEvent {
-    BLEMeshRadioFound(DeviceIdentifier, RadioType),
-    BLERadioLost(DeviceIdentifier),
+    MeshRadioFound(DeviceIdentifier, RadioType),
+    MeshRadioLost(DeviceIdentifier),
     CriticalError(String),
     Error(String),
     StartEditingAlias(String),
@@ -80,7 +80,7 @@ const ALIAS_INPUT_TEXT_ID: &str = "alias_input_text";
 impl DeviceList {
     pub fn update(&mut self, device_list_event: DeviceListEvent) -> Task<Message> {
         match device_list_event {
-            BLEMeshRadioFound(device, radio_type) => {
+            MeshRadioFound(device, radio_type) => {
                 if let std::collections::hash_map::Entry::Vacant(vacant_entry) =
                     self.devices.entry(device.clone())
                 {
@@ -90,7 +90,7 @@ impl DeviceList {
                     });
                 }
             }
-            BLERadioLost(device) => {
+            MeshRadioLost(device) => {
                 let _ = self.devices.remove(&device);
             }
             Error(e) => {
@@ -245,6 +245,23 @@ impl DeviceList {
             };
             let icon = image(icon_handle).width(24).height(24);
             device_row = device_row.push(icon);
+            device_row = device_row.push(Space::new().width(8));
+
+            // Transport badge so the user can tell BLE devices apart from LAN/TCP devices.
+            let (transport_label, transport_tip) = match device_identifier {
+                DeviceIdentifier::Ble { .. } => ("BT", "Connected via Bluetooth LE".to_string()),
+                DeviceIdentifier::Tcp { host, port, .. } => {
+                    ("TCP", format!("Reachable over TCP at {host}:{port}"))
+                }
+            };
+            device_row = device_row.push(
+                tooltip(
+                    text(transport_label).size(11),
+                    text(transport_tip),
+                    tooltip::Position::Right,
+                )
+                .style(tooltip_style),
+            );
             device_row = device_row.push(Space::new().width(8));
 
             let name_element: Element<'a, Message> =
@@ -422,7 +439,7 @@ mod tests {
         let mut view = DeviceList::default();
         assert!(view.devices.is_empty());
 
-        let _ = view.update(BLEMeshRadioFound(
+        let _ = view.update(MeshRadioFound(
             DeviceIdentifier::from("AA:BB:CC:DD:EE:FF"),
             RadioType::Meshtastic,
         ));
@@ -439,11 +456,11 @@ mod tests {
     fn test_ble_radio_found_duplicate() {
         let mut view = DeviceList::default();
 
-        let _ = view.update(BLEMeshRadioFound(
+        let _ = view.update(MeshRadioFound(
             DeviceIdentifier::from("AA:BB:CC:DD:EE:FF"),
             RadioType::Meshtastic,
         ));
-        let _ = view.update(BLEMeshRadioFound(
+        let _ = view.update(MeshRadioFound(
             DeviceIdentifier::from("AA:BB:CC:DD:EE:FF"),
             RadioType::Meshtastic,
         ));
@@ -457,11 +474,11 @@ mod tests {
     fn test_ble_radio_found_multiple() {
         let mut view = DeviceList::default();
 
-        let _ = view.update(BLEMeshRadioFound(
+        let _ = view.update(MeshRadioFound(
             DeviceIdentifier::from("AA:BB:CC:DD:EE:FF"),
             RadioType::Meshtastic,
         ));
-        let _ = view.update(BLEMeshRadioFound(
+        let _ = view.update(MeshRadioFound(
             DeviceIdentifier::from("11:22:33:44:55:66"),
             RadioType::Meshtastic,
         ));
@@ -473,13 +490,13 @@ mod tests {
     fn test_ble_radio_lost() {
         let mut view = DeviceList::default();
 
-        let _ = view.update(BLEMeshRadioFound(
+        let _ = view.update(MeshRadioFound(
             DeviceIdentifier::from("AA:BB:CC:DD:EE:FF"),
             RadioType::Meshtastic,
         ));
         assert_eq!(view.devices.len(), 1);
 
-        let _ = view.update(BLERadioLost(DeviceIdentifier::from("AA:BB:CC:DD:EE:FF")));
+        let _ = view.update(MeshRadioLost(DeviceIdentifier::from("AA:BB:CC:DD:EE:FF")));
         assert!(view.devices.is_empty());
     }
 
@@ -488,7 +505,7 @@ mod tests {
         let mut view = DeviceList::default();
 
         // Losing a device that was never found should not panic
-        let _ = view.update(BLERadioLost(DeviceIdentifier::from("AA:BB:CC:DD:EE:FF")));
+        let _ = view.update(MeshRadioLost(DeviceIdentifier::from("AA:BB:CC:DD:EE:FF")));
         assert!(view.devices.is_empty());
     }
 
@@ -586,7 +603,7 @@ mod tests {
         let mut config = Config::default();
 
         // Find a device
-        let _ = view.update(BLEMeshRadioFound(
+        let _ = view.update(MeshRadioFound(
             DeviceIdentifier::from("AA:BB:CC:DD:EE:FF"),
             RadioType::Meshtastic,
         ));
@@ -613,7 +630,7 @@ mod tests {
         );
 
         // Lose the device
-        let _ = view.update(BLERadioLost(DeviceIdentifier::from("AA:BB:CC:DD:EE:FF")));
+        let _ = view.update(MeshRadioLost(DeviceIdentifier::from("AA:BB:CC:DD:EE:FF")));
         assert!(view.devices.is_empty());
     }
 
@@ -621,17 +638,17 @@ mod tests {
     // Test DeviceListEvent enum
     #[test]
     fn test_device_list_event_debug() {
-        let event = BLEMeshRadioFound("device1".into(), RadioType::Meshtastic);
+        let event = MeshRadioFound("device1".into(), RadioType::Meshtastic);
         let debug_str = format!("{:?}", event);
-        assert!(debug_str.contains("BLEMeshRadioFound"));
+        assert!(debug_str.contains("MeshRadioFound"));
         assert!(debug_str.contains("device1"));
     }
 
     #[test]
     fn test_device_list_event_clone() {
-        let event = BLERadioLost("device1".into());
+        let event = MeshRadioLost("device1".into());
         let cloned = event.clone();
-        assert!(matches!(cloned, BLERadioLost(name) if name == DeviceIdentifier::from("device1")));
+        assert!(matches!(cloned, MeshRadioLost(name) if name == DeviceIdentifier::from("device1")));
     }
 
     #[test]
@@ -681,13 +698,13 @@ mod tests {
         let mut view = DeviceList::default();
 
         // Add multiple devices
-        let _ = view.update(BLEMeshRadioFound("device1".into(), RadioType::Meshtastic));
-        let _ = view.update(BLEMeshRadioFound("device2".into(), RadioType::Meshtastic));
-        let _ = view.update(BLEMeshRadioFound("device3".into(), RadioType::Meshtastic));
+        let _ = view.update(MeshRadioFound("device1".into(), RadioType::Meshtastic));
+        let _ = view.update(MeshRadioFound("device2".into(), RadioType::Meshtastic));
+        let _ = view.update(MeshRadioFound("device3".into(), RadioType::Meshtastic));
         assert_eq!(view.devices.len(), 3);
 
         // Remove one
-        let _ = view.update(BLERadioLost("device2".into()));
+        let _ = view.update(MeshRadioLost("device2".into()));
         assert_eq!(view.devices.len(), 2);
         assert!(
             view.devices
@@ -704,11 +721,11 @@ mod tests {
         );
 
         // Remove another
-        let _ = view.update(BLERadioLost("device1".into()));
+        let _ = view.update(MeshRadioLost("device1".into()));
         assert_eq!(view.devices.len(), 1);
 
         // Remove last
-        let _ = view.update(BLERadioLost("device3".into()));
+        let _ = view.update(MeshRadioLost("device3".into()));
         assert!(view.devices.is_empty());
     }
 
@@ -762,7 +779,7 @@ mod tests {
         let mut view = DeviceList::default();
 
         // Find device
-        let _ = view.update(BLEMeshRadioFound("device1".into(), RadioType::Meshtastic));
+        let _ = view.update(MeshRadioFound("device1".into(), RadioType::Meshtastic));
 
         // Start editing alias
         let _ = view.update(StartEditingAlias("device1".into()));
@@ -770,7 +787,7 @@ mod tests {
         assert_eq!(view.editing_alias, Some("device1".into()));
 
         // Device is lost while editing
-        let _ = view.update(BLERadioLost("device1".into()));
+        let _ = view.update(MeshRadioLost("device1".into()));
         assert!(view.devices.is_empty());
 
         // Editing state is still preserved (caller needs to handle this)
@@ -810,7 +827,7 @@ mod tests {
         let mut view = DeviceList::default();
         let long_name = DeviceIdentifier::from("B".repeat(100).as_str());
 
-        let _ = view.update(BLEMeshRadioFound(long_name.clone(), RadioType::Meshtastic));
+        let _ = view.update(MeshRadioFound(long_name.clone(), RadioType::Meshtastic));
         assert!(view.devices.contains_key(&long_name));
     }
 
@@ -828,7 +845,7 @@ mod tests {
         let mut view = DeviceList::default();
         assert!(view.devices.is_empty());
 
-        let _ = view.update(BLEMeshRadioFound(
+        let _ = view.update(MeshRadioFound(
             DeviceIdentifier::from("AA:BB:CC:DD:EE:FF"),
             RadioType::MeshCore,
         ));
@@ -852,11 +869,11 @@ mod tests {
     fn test_ble_meshcore_radio_found_duplicate() {
         let mut view = DeviceList::default();
 
-        let _ = view.update(BLEMeshRadioFound(
+        let _ = view.update(MeshRadioFound(
             DeviceIdentifier::from("AA:BB:CC:DD:EE:FF"),
             RadioType::MeshCore,
         ));
-        let _ = view.update(BLEMeshRadioFound(
+        let _ = view.update(MeshRadioFound(
             DeviceIdentifier::from("AA:BB:CC:DD:EE:FF"),
             RadioType::MeshCore,
         ));
@@ -906,11 +923,11 @@ mod tests {
 
     #[test]
     fn test_device_list_event_ble_radio_lost_clone() {
-        let event = BLERadioLost("device1".into());
+        let event = MeshRadioLost("device1".into());
         let cloned = event.clone();
         assert!(
-            matches!(cloned, BLERadioLost(ref name) if name == &DeviceIdentifier::from("device1")),
-            "Clone of BLERadioLost should preserve device name, got {:?}",
+            matches!(cloned, MeshRadioLost(ref name) if name == &DeviceIdentifier::from("device1")),
+            "Clone of MeshRadioLost should preserve device name, got {:?}",
             cloned
         );
     }
@@ -952,7 +969,7 @@ mod tests {
     #[test]
     fn test_radio_type_meshtastic() {
         let mut view = DeviceList::default();
-        let _ = view.update(BLEMeshRadioFound(
+        let _ = view.update(MeshRadioFound(
             DeviceIdentifier::from("AA:BB:CC:DD:EE:FF"),
             RadioType::Meshtastic,
         ));
@@ -960,7 +977,7 @@ mod tests {
         let device_info = view
             .devices
             .get(&DeviceIdentifier::from("AA:BB:CC:DD:EE:FF"))
-            .expect("Device should exist after BLEMeshRadioFound event");
+            .expect("Device should exist after MeshRadioFound event");
         assert_eq!(device_info.radio_type, RadioType::Meshtastic);
     }
 
@@ -977,13 +994,13 @@ mod tests {
         let mut view = DeviceList::default();
 
         // Add some devices
-        let _ = view.update(BLEMeshRadioFound("device1".into(), RadioType::Meshtastic));
-        let _ = view.update(BLEMeshRadioFound("device2".into(), RadioType::Meshtastic));
+        let _ = view.update(MeshRadioFound("device1".into(), RadioType::Meshtastic));
+        let _ = view.update(MeshRadioFound("device2".into(), RadioType::Meshtastic));
         assert_eq!(view.devices.len(), 2);
 
         // Remove all
-        let _ = view.update(BLERadioLost("device1".into()));
-        let _ = view.update(BLERadioLost("device2".into()));
+        let _ = view.update(MeshRadioLost("device1".into()));
+        let _ = view.update(MeshRadioLost("device2".into()));
         assert!(view.devices.is_empty());
     }
 
@@ -1002,8 +1019,8 @@ mod tests {
     #[test]
     fn test_view_with_devices_disconnected() {
         let mut view = DeviceList::default();
-        let _ = view.update(BLEMeshRadioFound("device1".into(), RadioType::Meshtastic));
-        let _ = view.update(BLEMeshRadioFound("device2".into(), RadioType::Meshtastic));
+        let _ = view.update(MeshRadioFound("device1".into(), RadioType::Meshtastic));
+        let _ = view.update(MeshRadioFound("device2".into(), RadioType::Meshtastic));
 
         let config = Config::default();
         let connection_state = Disconnected(None, None);
@@ -1015,7 +1032,7 @@ mod tests {
     #[test]
     fn test_view_with_device_connecting() {
         let mut view = DeviceList::default();
-        let _ = view.update(BLEMeshRadioFound("device1".into(), RadioType::Meshtastic));
+        let _ = view.update(MeshRadioFound("device1".into(), RadioType::Meshtastic));
 
         let config = Config::default();
         let connection_state = Connecting("device1".into());
@@ -1027,7 +1044,7 @@ mod tests {
     #[test]
     fn test_view_with_device_connected() {
         let mut view = DeviceList::default();
-        let _ = view.update(BLEMeshRadioFound("device1".into(), RadioType::Meshtastic));
+        let _ = view.update(MeshRadioFound("device1".into(), RadioType::Meshtastic));
 
         let config = Config::default();
         let connection_state = Connected("device1".into(), RadioType::Meshtastic);
@@ -1039,7 +1056,7 @@ mod tests {
     #[test]
     fn test_view_with_device_disconnecting() {
         let mut view = DeviceList::default();
-        let _ = view.update(BLEMeshRadioFound("device1".into(), RadioType::Meshtastic));
+        let _ = view.update(MeshRadioFound("device1".into(), RadioType::Meshtastic));
 
         let config = Config::default();
         let connection_state = Disconnecting("device1".into());
@@ -1051,7 +1068,7 @@ mod tests {
     #[test]
     fn test_view_with_alias() {
         let mut view = DeviceList::default();
-        let _ = view.update(BLEMeshRadioFound("device1".into(), RadioType::Meshtastic));
+        let _ = view.update(MeshRadioFound("device1".into(), RadioType::Meshtastic));
 
         let mut config = Config::default();
         config
@@ -1067,7 +1084,7 @@ mod tests {
     #[test]
     fn test_view_while_editing_alias() {
         let mut view = DeviceList::default();
-        let _ = view.update(BLEMeshRadioFound("device1".into(), RadioType::Meshtastic));
+        let _ = view.update(MeshRadioFound("device1".into(), RadioType::Meshtastic));
         let _ = view.update(StartEditingAlias("device1".into()));
         let _ = view.update(AliasInput("New Alias".into()));
 
@@ -1132,7 +1149,7 @@ mod tests {
     fn test_view_many_devices() {
         let mut view = DeviceList::default();
         for i in 0..20 {
-            let _ = view.update(BLEMeshRadioFound(
+            let _ = view.update(MeshRadioFound(
                 DeviceIdentifier::from(format!("device{}", i)),
                 RadioType::Meshtastic,
             ));
@@ -1160,7 +1177,7 @@ mod tests {
     #[test]
     fn test_view_shows_connect_button_when_disconnected() {
         let mut view = DeviceList::default();
-        let _ = view.update(BLEMeshRadioFound("device1".into(), RadioType::Meshtastic));
+        let _ = view.update(MeshRadioFound("device1".into(), RadioType::Meshtastic));
 
         let config = Config::default();
 
@@ -1174,7 +1191,7 @@ mod tests {
     #[test]
     fn test_view_shows_disconnect_button_when_connected_to_this_device() {
         let mut view = DeviceList::default();
-        let _ = view.update(BLEMeshRadioFound("device1".into(), RadioType::Meshtastic));
+        let _ = view.update(MeshRadioFound("device1".into(), RadioType::Meshtastic));
 
         let config = Config::default();
 
@@ -1188,7 +1205,7 @@ mod tests {
     #[test]
     fn test_view_shows_nothing_when_connected_to_different_device() {
         let mut view = DeviceList::default();
-        let _ = view.update(BLEMeshRadioFound("device1".into(), RadioType::Meshtastic));
+        let _ = view.update(MeshRadioFound("device1".into(), RadioType::Meshtastic));
 
         let config = Config::default();
 
@@ -1202,7 +1219,7 @@ mod tests {
     #[test]
     fn test_view_shows_connecting_when_connecting_to_this_device() {
         let mut view = DeviceList::default();
-        let _ = view.update(BLEMeshRadioFound("device1".into(), RadioType::Meshtastic));
+        let _ = view.update(MeshRadioFound("device1".into(), RadioType::Meshtastic));
 
         let config = Config::default();
 
@@ -1216,7 +1233,7 @@ mod tests {
     #[test]
     fn test_view_shows_nothing_when_connecting_to_different_device() {
         let mut view = DeviceList::default();
-        let _ = view.update(BLEMeshRadioFound("device1".into(), RadioType::Meshtastic));
+        let _ = view.update(MeshRadioFound("device1".into(), RadioType::Meshtastic));
 
         let config = Config::default();
 
@@ -1230,7 +1247,7 @@ mod tests {
     #[test]
     fn test_view_shows_disconnecting_when_disconnecting_this_device() {
         let mut view = DeviceList::default();
-        let _ = view.update(BLEMeshRadioFound("device1".into(), RadioType::Meshtastic));
+        let _ = view.update(MeshRadioFound("device1".into(), RadioType::Meshtastic));
 
         let config = Config::default();
 
@@ -1243,7 +1260,7 @@ mod tests {
     #[test]
     fn test_view_shows_nothing_when_disconnecting_different_device() {
         let mut view = DeviceList::default();
-        let _ = view.update(BLEMeshRadioFound("device1".into(), RadioType::Meshtastic));
+        let _ = view.update(MeshRadioFound("device1".into(), RadioType::Meshtastic));
 
         let config = Config::default();
 
@@ -1256,8 +1273,8 @@ mod tests {
     #[test]
     fn test_view_alias_vs_original_name() {
         let mut view = DeviceList::default();
-        let _ = view.update(BLEMeshRadioFound("device1".into(), RadioType::Meshtastic));
-        let _ = view.update(BLEMeshRadioFound("device2".into(), RadioType::Meshtastic));
+        let _ = view.update(MeshRadioFound("device1".into(), RadioType::Meshtastic));
+        let _ = view.update(MeshRadioFound("device2".into(), RadioType::Meshtastic));
 
         let mut config = Config::default();
         // device1 has an alias, device2 does not
@@ -1274,8 +1291,8 @@ mod tests {
     #[test]
     fn test_view_editing_alias_shows_text_input() {
         let mut view = DeviceList::default();
-        let _ = view.update(BLEMeshRadioFound("device1".into(), RadioType::Meshtastic));
-        let _ = view.update(BLEMeshRadioFound("device2".into(), RadioType::Meshtastic));
+        let _ = view.update(MeshRadioFound("device1".into(), RadioType::Meshtastic));
+        let _ = view.update(MeshRadioFound("device2".into(), RadioType::Meshtastic));
 
         // Start editing alias for device1
         let _ = view.update(StartEditingAlias("device1".into()));
@@ -1308,13 +1325,13 @@ mod tests {
 
         // Add devices of different types
         #[cfg(feature = "meshtastic")]
-        let _ = view.update(BLEMeshRadioFound(
+        let _ = view.update(MeshRadioFound(
             "meshtastic_device".into(),
             RadioType::Meshtastic,
         ));
 
         #[cfg(feature = "meshcore")]
-        let _ = view.update(BLEMeshRadioFound(
+        let _ = view.update(MeshRadioFound(
             "meshcore_device".into(),
             RadioType::Meshtastic,
         ));
@@ -1377,11 +1394,11 @@ mod tests {
 
         // Start scanning and find a device
         let _ = view.update(Scanning(true));
-        let _ = view.update(BLEMeshRadioFound("device1".into(), RadioType::Meshtastic));
+        let _ = view.update(MeshRadioFound("device1".into(), RadioType::Meshtastic));
         assert_eq!(view.devices.len(), 1);
 
         // Lose the device while still scanning
-        let _ = view.update(BLERadioLost("device1".into()));
+        let _ = view.update(MeshRadioLost("device1".into()));
         assert!(view.devices.is_empty());
         assert!(view.scanning);
 

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -1,32 +1,48 @@
+#[cfg(any(feature = "bluetooth", feature = "tcp"))]
 use crate::device::DeviceIdentifier;
+#[cfg(any(feature = "bluetooth", feature = "tcp"))]
 use crate::device_list::DeviceListEvent;
-use crate::device_list::DeviceListEvent::{
-    CriticalError, Error, MeshRadioFound, MeshRadioLost, Scanning,
-};
+#[cfg(any(feature = "bluetooth", feature = "tcp"))]
+use crate::device_list::DeviceListEvent::Error;
+#[cfg(feature = "bluetooth")]
+use crate::device_list::DeviceListEvent::{CriticalError, Scanning};
+#[cfg(any(feature = "bluetooth", feature = "tcp"))]
+use crate::device_list::DeviceListEvent::{MeshRadioFound, MeshRadioLost};
+#[cfg(any(feature = "bluetooth", feature = "tcp"))]
 use crate::device_list::RadioType;
 #[cfg(feature = "meshcore")]
 use crate::meshc::MESHCORE_SERVICE_UUID;
-#[cfg(feature = "meshtastic")]
+#[cfg(all(feature = "meshtastic", feature = "bluetooth"))]
 use crate::mesht::MESHTASTIC_SERVICE_UUID;
+#[cfg(feature = "bluetooth")]
 use btleplug::api::{Central, Manager as _, Peripheral, ScanFilter};
+#[cfg(feature = "bluetooth")]
 use btleplug::platform::{Adapter, Manager};
+#[cfg(any(feature = "bluetooth", feature = "tcp"))]
 use futures::SinkExt;
+#[cfg(any(feature = "bluetooth", feature = "tcp"))]
 use futures_channel::mpsc::Sender;
+#[cfg(any(feature = "bluetooth", feature = "tcp"))]
 use iced::futures::Stream;
+#[cfg(any(feature = "bluetooth", feature = "tcp"))]
 use iced::stream;
-#[cfg(feature = "meshtastic")]
+#[cfg(feature = "tcp")]
 use mdns_sd::{ServiceDaemon, ServiceEvent};
+#[cfg(any(feature = "bluetooth", feature = "tcp"))]
 use std::collections::HashMap;
-#[cfg(feature = "meshtastic")]
+#[cfg(feature = "tcp")]
 use std::net::IpAddr;
+#[cfg(feature = "bluetooth")]
 use std::time::Duration;
+#[cfg(feature = "bluetooth")]
 use uuid::Uuid;
 
 /// mDNS service type advertised by Meshtastic devices for their TCP API (port 4403 by default).
-#[cfg(feature = "meshtastic")]
+#[cfg(feature = "tcp")]
 const MESHTASTIC_MDNS_SERVICE: &str = "_meshtastic._tcp.local.";
 
 /// A stream of [DeviceListEvent] announcing the discovery or loss of devices via BLE
+#[cfg(feature = "bluetooth")]
 pub fn ble_discovery() -> impl Stream<Item = DeviceListEvent> {
     #[allow(unused_mut)]
     let mut service_filter: Vec<Uuid> = vec![];
@@ -87,6 +103,7 @@ pub fn ble_discovery() -> impl Stream<Item = DeviceListEvent> {
     )
 }
 
+#[cfg(feature = "bluetooth")]
 async fn scan_for_devices(gui_sender: &mut Sender<DeviceListEvent>, adapter: &Adapter) {
     // Device name -> (unseen count, radio type)
     let mut mesh_radio_devices: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
@@ -114,8 +131,10 @@ async fn scan_for_devices(gui_sender: &mut Sender<DeviceListEvent>, adapter: &Ad
     }
 }
 
+#[cfg(feature = "bluetooth")]
 const DEFAULT_MAC: [u8; 6] = [0x00; 6];
 
+#[cfg(feature = "bluetooth")]
 async fn announce_device_changes(
     gui_sender: &mut Sender<DeviceListEvent>,
     peripherals: &Vec<impl Peripheral>,
@@ -163,7 +182,7 @@ async fn announce_device_changes(
     }
 }
 
-/// Detect the radio type from the service UUIDs advertised by the peripheral
+#[cfg(feature = "bluetooth")]
 #[allow(unused_variables)]
 fn detect_radio_type(services: &[Uuid]) -> Option<RadioType> {
     #[cfg(feature = "meshtastic")]
@@ -178,8 +197,7 @@ fn detect_radio_type(services: &[Uuid]) -> Option<RadioType> {
     None
 }
 
-/// Process device changes and return events to send.
-/// Returns (devices_found with radio type, devices_lost)
+#[cfg(feature = "bluetooth")]
 fn process_device_changes(
     current_devices: &HashMap<DeviceIdentifier, RadioType>,
     tracked_devices: &mut HashMap<DeviceIdentifier, (i32, RadioType)>,
@@ -220,7 +238,7 @@ fn process_device_changes(
 /// A stream of [DeviceListEvent] announcing the discovery or loss of Meshtastic devices reachable
 /// over TCP on the local network. Devices advertise themselves via mDNS-SD as
 /// `_meshtastic._tcp.local.`.
-#[cfg(feature = "meshtastic")]
+#[cfg(feature = "tcp")]
 pub fn mdns_discovery() -> impl Stream<Item = DeviceListEvent> {
     stream::channel(
         100,
@@ -278,9 +296,11 @@ pub fn mdns_discovery() -> impl Stream<Item = DeviceListEvent> {
                             .map(|s| s.to_string());
 
                         let identifier = DeviceIdentifier::Tcp { name, host, port };
-                        if resolved.insert(fullname, identifier.clone()).as_ref()
-                            != Some(&identifier)
-                        {
+                        let previous = resolved.insert(fullname, identifier.clone());
+                        if previous.as_ref() != Some(&identifier) {
+                            if let Some(old) = previous {
+                                let _ = gui_sender.send(MeshRadioLost(old)).await;
+                            }
                             let _ = gui_sender
                                 .send(MeshRadioFound(identifier, RadioType::Meshtastic))
                                 .await;
@@ -302,8 +322,7 @@ pub fn mdns_discovery() -> impl Stream<Item = DeviceListEvent> {
 mod tests {
     use super::*;
 
-    #[cfg(feature = "meshtastic")]
-    /// Helper to create a HashMap of device names with default RadioType
+    #[cfg(all(feature = "meshtastic", feature = "bluetooth"))]
     fn devices(items: &[&str]) -> HashMap<DeviceIdentifier, RadioType> {
         items
             .iter()
@@ -311,8 +330,7 @@ mod tests {
             .collect()
     }
 
-    #[cfg(feature = "meshtastic")]
-    /// Helper to create a tracked device's HashMap entry
+    #[cfg(all(feature = "meshtastic", feature = "bluetooth"))]
     fn tracked_device(name: &str, unseen_count: i32) -> (DeviceIdentifier, (i32, RadioType)) {
         (
             DeviceIdentifier::from(name),
@@ -320,969 +338,975 @@ mod tests {
         )
     }
 
-    // Test discovering new devices
-    #[test]
-    fn test_new_device_found() {
-        let current = devices(&["Device1"]);
-        let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
-
-        let (found, lost) = process_device_changes(&current, &mut tracked);
-
-        assert_eq!(found.len(), 1);
-        assert_eq!(found[0].0, DeviceIdentifier::from("Device1"));
-        assert!(lost.is_empty());
-        assert_eq!(
-            tracked
-                .get(&DeviceIdentifier::from("Device1"))
-                .map(|(c, _)| *c),
-            Some(0)
-        );
-    }
-
-    #[test]
-    fn test_multiple_new_devices_found() {
-        let current = devices(&["Device1", "Device2", "Device3"]);
-        let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
-
-        let (found, lost) = process_device_changes(&current, &mut tracked);
-
-        assert_eq!(found.len(), 3);
-        let found_names: Vec<_> = found.iter().map(|(name, _)| String::from(name)).collect();
-        assert!(found_names.contains(&"Device1".to_string()));
-        assert!(found_names.contains(&"Device2".to_string()));
-        assert!(found_names.contains(&"Device3".to_string()));
-        assert!(lost.is_empty());
-        assert_eq!(tracked.len(), 3);
-    }
-
-    #[test]
-    fn test_no_devices() {
-        let current: HashMap<DeviceIdentifier, RadioType> = HashMap::new();
-        let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
-
-        let (found, lost) = process_device_changes(&current, &mut tracked);
-
-        assert!(found.is_empty());
-        assert!(lost.is_empty());
-        assert!(tracked.is_empty());
-    }
-
-    // Test device still present
-    #[test]
-    fn test_device_still_present() {
-        let current = devices(&["Device1"]);
-        let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
-        tracked.insert(
-            tracked_device("Device1", 0).0,
-            tracked_device("Device1", 0).1,
-        );
-
-        let (found, lost) = process_device_changes(&current, &mut tracked);
-
-        assert!(found.is_empty());
-        assert!(lost.is_empty());
-        assert_eq!(
-            tracked
-                .get(&DeviceIdentifier::from("Device1"))
-                .map(|(c, _)| *c),
-            Some(0)
-        );
-    }
-
-    #[test]
-    fn test_device_reappears_resets_count() {
-        let current = devices(&["Device1"]);
-        let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
-        tracked.insert(
-            tracked_device("Device1", 2).0,
-            tracked_device("Device1", 2).1,
-        );
-
-        let (found, lost) = process_device_changes(&current, &mut tracked);
-
-        assert!(found.is_empty());
-        assert!(lost.is_empty());
-        // Count should be reset to 0
-        assert_eq!(
-            tracked
-                .get(&DeviceIdentifier::from("Device1"))
-                .map(|(c, _)| *c),
-            Some(0)
-        );
-    }
-
-    // Test device disappearing
-    #[test]
-    fn test_device_unseen_once() {
-        let current: HashMap<DeviceIdentifier, RadioType> = HashMap::new();
-        let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
-        tracked.insert(
-            tracked_device("Device1", 0).0,
-            tracked_device("Device1", 0).1,
-        );
-
-        let (found, lost) = process_device_changes(&current, &mut tracked);
-
-        assert!(found.is_empty());
-        assert!(lost.is_empty()); // Not lost yet, only unseen once
-        assert_eq!(
-            tracked
-                .get(&DeviceIdentifier::from("Device1"))
-                .map(|(c, _)| *c),
-            Some(1)
-        );
-    }
-
-    #[test]
-    fn test_device_unseen_twice() {
-        let current: HashMap<DeviceIdentifier, RadioType> = HashMap::new();
-        let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
-        tracked.insert(
-            tracked_device("Device1", 1).0,
-            tracked_device("Device1", 1).1,
-        );
-
-        let (found, lost) = process_device_changes(&current, &mut tracked);
-
-        assert!(found.is_empty());
-        assert!(lost.is_empty()); // Not lost yet, only unseen twice
-        assert_eq!(
-            tracked
-                .get(&DeviceIdentifier::from("Device1"))
-                .map(|(c, _)| *c),
-            Some(2)
-        );
-    }
-
-    #[test]
-    fn test_device_lost_after_three_unseen() {
-        let current: HashMap<DeviceIdentifier, RadioType> = HashMap::new();
-        let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
-        tracked.insert(
-            tracked_device("Device1", 2).0,
-            tracked_device("Device1", 2).1,
-        );
-
-        let (found, lost) = process_device_changes(&current, &mut tracked);
-
-        assert!(found.is_empty());
-        assert_eq!(lost, vec![DeviceIdentifier::from("Device1")]);
-        // Device should be removed from tracking
-        assert!(!tracked.contains_key(&DeviceIdentifier::from("Device1")));
-    }
-
-    #[test]
-    fn test_device_removed_from_tracking_after_lost() {
-        let current: HashMap<DeviceIdentifier, RadioType> = HashMap::new();
-        let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
-        tracked.insert(
-            tracked_device("Device1", 2).0,
-            tracked_device("Device1", 2).1,
-        );
-
-        process_device_changes(&current, &mut tracked);
-
-        assert!(tracked.is_empty());
-    }
-
-    // Test mixed scenarios
-    #[test]
-    fn test_one_found_one_still_present() {
-        let current = devices(&["Device1", "Device2"]);
-        let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
-        tracked.insert(
-            tracked_device("Device1", 0).0,
-            tracked_device("Device1", 0).1,
-        );
-
-        let (found, lost) = process_device_changes(&current, &mut tracked);
-
-        assert_eq!(found.len(), 1);
-        assert_eq!(found[0].0, DeviceIdentifier::from("Device2"));
-        assert!(lost.is_empty());
-        assert_eq!(tracked.len(), 2);
-    }
-
-    #[test]
-    fn test_one_found_one_disappearing() {
-        let current = devices(&["Device2"]);
-        let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
-        tracked.insert(
-            tracked_device("Device1", 0).0,
-            tracked_device("Device1", 0).1,
-        );
-
-        let (found, lost) = process_device_changes(&current, &mut tracked);
-
-        assert_eq!(found.len(), 1);
-        assert_eq!(found[0].0, DeviceIdentifier::from("Device2"));
-        assert!(lost.is_empty()); // Device1 not lost yet
-        assert_eq!(
-            tracked
-                .get(&DeviceIdentifier::from("Device1"))
-                .map(|(c, _)| *c),
-            Some(1)
-        );
-        assert_eq!(
-            tracked
-                .get(&DeviceIdentifier::from("Device2"))
-                .map(|(c, _)| *c),
-            Some(0)
-        );
-    }
-
-    #[test]
-    fn test_one_found_one_lost() {
-        let current = devices(&["Device2"]);
-        let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
-        tracked.insert(
-            tracked_device("Device1", 2).0,
-            tracked_device("Device1", 2).1,
-        );
-
-        let (found, lost) = process_device_changes(&current, &mut tracked);
-
-        assert_eq!(found.len(), 1);
-        assert_eq!(found[0].0, DeviceIdentifier::from("Device2"));
-        assert_eq!(lost, vec![DeviceIdentifier::from("Device1")]);
-        assert!(!tracked.contains_key(&DeviceIdentifier::from("Device1")));
-        assert_eq!(
-            tracked
-                .get(&DeviceIdentifier::from("Device2"))
-                .map(|(c, _)| *c),
-            Some(0)
-        );
-    }
-
-    #[test]
-    fn test_multiple_devices_different_states() {
-        let current = devices(&["Device1", "Device4"]);
-        let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
-        tracked.insert(
-            tracked_device("Device1", 1).0,
-            tracked_device("Device1", 1).1,
-        );
-        tracked.insert(
-            tracked_device("Device2", 0).0,
-            tracked_device("Device2", 0).1,
-        );
-        tracked.insert(
-            tracked_device("Device3", 2).0,
-            tracked_device("Device3", 2).1,
-        );
-
-        let (found, lost) = process_device_changes(&current, &mut tracked);
-
-        assert_eq!(found.len(), 1);
-        assert_eq!(found[0].0, DeviceIdentifier::from("Device4"));
-        assert_eq!(lost, vec![DeviceIdentifier::from("Device3")]);
-        assert_eq!(
-            tracked
-                .get(&DeviceIdentifier::from("Device1"))
-                .map(|(c, _)| *c),
-            Some(0)
-        ); // Reset
-        assert_eq!(
-            tracked
-                .get(&DeviceIdentifier::from("Device2"))
-                .map(|(c, _)| *c),
-            Some(1)
-        ); // Incremented
-        assert!(!tracked.contains_key(&DeviceIdentifier::from("Device3"))); // Removed
-        assert_eq!(
-            tracked
-                .get(&DeviceIdentifier::from("Device4"))
-                .map(|(c, _)| *c),
-            Some(0)
-        ); // New
-    }
-
-    // Test the full lifecycle
-    #[test]
-    fn test_device_full_lifecycle() {
-        let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
-
-        // Cycle 1: Device appears
-        let current = devices(&["Device1"]);
-        let (found, lost) = process_device_changes(&current, &mut tracked);
-        assert_eq!(found.len(), 1);
-        assert_eq!(found[0].0, DeviceIdentifier::from("Device1"));
-        assert!(lost.is_empty());
-        assert_eq!(
-            tracked
-                .get(&DeviceIdentifier::from("Device1"))
-                .map(|(c, _)| *c),
-            Some(0)
-        );
-
-        // Cycle 2: Device still present
-        let (found, lost) = process_device_changes(&current, &mut tracked);
-        assert!(found.is_empty());
-        assert!(lost.is_empty());
-        assert_eq!(
-            tracked
-                .get(&DeviceIdentifier::from("Device1"))
-                .map(|(c, _)| *c),
-            Some(0)
-        );
-
-        // Cycle 3: Device disappears (unseen 1)
-        let current: HashMap<DeviceIdentifier, RadioType> = HashMap::new();
-        let (found, lost) = process_device_changes(&current, &mut tracked);
-        assert!(found.is_empty());
-        assert!(lost.is_empty());
-        assert_eq!(
-            tracked
-                .get(&DeviceIdentifier::from("Device1"))
-                .map(|(c, _)| *c),
-            Some(1)
-        );
-
-        // Cycle 4: Device still gone (unseen 2)
-        let (found, lost) = process_device_changes(&current, &mut tracked);
-        assert!(found.is_empty());
-        assert!(lost.is_empty());
-        assert_eq!(
-            tracked
-                .get(&DeviceIdentifier::from("Device1"))
-                .map(|(c, _)| *c),
-            Some(2)
-        );
-
-        // Cycle 5: Device still gone (unseen 3 - lost)
-        let (found, lost) = process_device_changes(&current, &mut tracked);
-        assert!(found.is_empty());
-        assert_eq!(lost, vec![DeviceIdentifier::from("Device1")]);
-        assert!(!tracked.contains_key(&DeviceIdentifier::from("Device1")));
-    }
-
-    #[test]
-    fn test_device_reappears_during_disappearing() {
-        let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
-        tracked.insert(
-            tracked_device("Device1", 2).0,
-            tracked_device("Device1", 2).1,
-        );
-
-        // Device reappears just in time
-        let current = devices(&["Device1"]);
-        let (found, lost) = process_device_changes(&current, &mut tracked);
-
-        assert!(found.is_empty()); // Not new, was tracked
-        assert!(lost.is_empty()); // Not lost, reappeared
-        assert_eq!(
-            tracked
-                .get(&DeviceIdentifier::from("Device1"))
-                .map(|(c, _)| *c),
-            Some(0)
-        ); // Count reset
-    }
-
-    #[test]
-    fn test_lost_device_can_be_found_again() {
-        let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
-
-        // Device appears
-        let current = devices(&["Device1"]);
-        process_device_changes(&current, &mut tracked);
-        assert!(tracked.contains_key(&DeviceIdentifier::from("Device1")));
-
-        // Device is lost after 3 cycles
-        let empty: HashMap<DeviceIdentifier, RadioType> = HashMap::new();
-        process_device_changes(&empty, &mut tracked); // unseen 1
-        process_device_changes(&empty, &mut tracked); // unseen 2
-        let (_, lost) = process_device_changes(&empty, &mut tracked); // unseen 3, lost
-        assert_eq!(lost, vec![DeviceIdentifier::from("Device1")]);
-        assert!(!tracked.contains_key(&DeviceIdentifier::from("Device1")));
-
-        // Device reappears - should be found as new
-        let (found, _) = process_device_changes(&current, &mut tracked);
-        assert_eq!(found.len(), 1);
-        assert_eq!(found[0].0, DeviceIdentifier::from("Device1"));
-        assert_eq!(
-            tracked
-                .get(&DeviceIdentifier::from("Device1"))
-                .map(|(c, _)| *c),
-            Some(0)
-        );
-    }
-
-    // Edge cases
-    #[test]
-    fn test_empty_to_empty() {
-        let current: HashMap<DeviceIdentifier, RadioType> = HashMap::new();
-        let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
-
-        let (found, lost) = process_device_changes(&current, &mut tracked);
-
-        assert!(found.is_empty());
-        assert!(lost.is_empty());
-        assert!(tracked.is_empty());
-    }
-
-    #[test]
-    fn test_device_with_special_characters() {
-        let current = devices(&["Device-1_test", "Device 2", "Device\t3"]);
-        let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
-
-        let (found, _) = process_device_changes(&current, &mut tracked);
-
-        assert_eq!(found.len(), 3);
-        assert!(tracked.contains_key(&DeviceIdentifier::from("Device-1_test")));
-        assert!(tracked.contains_key(&DeviceIdentifier::from("Device 2")));
-        assert!(tracked.contains_key(&DeviceIdentifier::from("Device\t3")));
-    }
-
-    #[test]
-    fn test_multiple_devices_lost_simultaneously() {
-        let current: HashMap<DeviceIdentifier, RadioType> = HashMap::new();
-        let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
-        tracked.insert(
-            tracked_device("Device1", 2).0,
-            tracked_device("Device1", 2).1,
-        );
-        tracked.insert(
-            tracked_device("Device2", 2).0,
-            tracked_device("Device2", 2).1,
-        );
-        tracked.insert(
-            tracked_device("Device3", 2).0,
-            tracked_device("Device3", 2).1,
-        );
-
-        let (found, lost) = process_device_changes(&current, &mut tracked);
-
-        assert!(found.is_empty());
-        assert_eq!(lost.len(), 3);
-        assert!(lost.contains(&DeviceIdentifier::from("Device1")));
-        assert!(lost.contains(&DeviceIdentifier::from("Device2")));
-        assert!(lost.contains(&DeviceIdentifier::from("Device3")));
-        assert!(tracked.is_empty());
-    }
-
-    // Test MSH_SERVICE constant
-    #[cfg(feature = "meshtastic")]
-    #[test]
-    fn test_msh_service_uuid() {
-        assert_eq!(
-            MESHTASTIC_SERVICE_UUID,
-            Uuid::from_u128(0x6ba1b218_15a8_461f_9fa8_5dcae273eafd)
-        );
-    }
-
-    #[cfg(feature = "meshcore")]
-    #[test]
-    fn test_meshcore_service_uuid() {
-        assert_eq!(
-            MESHCORE_SERVICE_UUID,
-            Uuid::from_u128(0x6e400001_b5a3_f393_e0a9_e50e24dcca9e)
-        );
-    }
-
-    // Test detect_radio_type function
-    #[cfg(feature = "meshtastic")]
-    #[test]
-    fn test_detect_radio_type_meshtastic() {
-        let services = vec![MESHTASTIC_SERVICE_UUID];
-        assert_eq!(detect_radio_type(&services), Some(RadioType::Meshtastic));
-    }
-
-    #[cfg(feature = "meshcore")]
-    #[test]
-    fn test_detect_radio_type_meshcore() {
-        let services = vec![MESHCORE_SERVICE_UUID];
-        assert_eq!(detect_radio_type(&services), Some(RadioType::MeshCore));
-    }
-
-    #[test]
-    fn test_detect_radio_type_empty() {
-        let services: Vec<Uuid> = vec![];
-        // Should return default
-        assert_eq!(detect_radio_type(&services), None);
-    }
-
-    #[test]
-    fn test_detect_radio_type_unknown_uuid() {
-        let services = vec![Uuid::from_u128(0x12345678_1234_1234_1234_123456789abc)];
-        // Should return default
-        assert_eq!(detect_radio_type(&services), None);
-    }
-
-    // Async tests for announce_device_changes
-    use futures_channel::mpsc;
-
-    // Mock peripheral for testing - we can't easily implement Peripheral trait,
-    // but we can test with empty vectors
-    #[tokio::test]
-    async fn test_announce_device_changes_empty_peripherals_empty_tracked() {
-        let (mut sender, mut receiver) = mpsc::channel::<DeviceListEvent>(10);
-        let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
-        let peripherals: Vec<btleplug::platform::Peripheral> = vec![];
-
-        announce_device_changes(&mut sender, &peripherals, &mut tracked).await;
-
-        // Close the sender to signal no more messages
-        sender.close_channel();
-
-        // No events should be sent
-        assert!(
-            receiver.try_recv().is_err(),
-            "Expected no events but received one"
-        );
-        assert!(tracked.is_empty());
-    }
-
-    #[tokio::test]
-    async fn test_announce_device_changes_empty_peripherals_with_tracked_unseen_once() {
-        let (mut sender, mut receiver) = mpsc::channel::<DeviceListEvent>(10);
-        let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
-        tracked.insert(
-            tracked_device("Device1", 0).0,
-            tracked_device("Device1", 0).1,
-        );
-        let peripherals: Vec<btleplug::platform::Peripheral> = vec![];
-
-        announce_device_changes(&mut sender, &peripherals, &mut tracked).await;
-
-        sender.close_channel();
-
-        // No events should be sent (the device has only been unseen once)
-        assert!(
-            receiver.try_recv().is_err(),
-            "Expected no events but received one"
-        );
-        // Device should still be tracked with incremented count
-        assert_eq!(
-            tracked
-                .get(&DeviceIdentifier::from("Device1"))
-                .map(|(c, _)| *c),
-            Some(1)
-        );
-    }
-
-    #[tokio::test]
-    async fn test_announce_device_changes_empty_peripherals_device_lost() {
-        let (mut sender, mut receiver) = mpsc::channel::<DeviceListEvent>(10);
-        let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
-        tracked.insert(
-            tracked_device("Device1", 2).0,
-            tracked_device("Device1", 2).1,
-        );
-        let peripherals: Vec<btleplug::platform::Peripheral> = vec![];
-
-        announce_device_changes(&mut sender, &peripherals, &mut tracked).await;
-
-        sender.close_channel();
-
-        // Should receive MeshRadioLost event
-        let event = receiver.try_recv().expect("Expected MeshRadioLost event");
-        assert!(
-            matches!(event, MeshRadioLost(device_id) if device_id == DeviceIdentifier::from("Device1"))
-        );
-
-        // No more events
-        assert!(
-            receiver.try_recv().is_err(),
-            "Expected no more events but received one"
-        );
-
-        // Device should be removed from tracking
-        assert!(!tracked.contains_key(&DeviceIdentifier::from("Device1")));
-    }
-
-    #[tokio::test]
-    async fn test_announce_device_changes_multiple_devices_lost() {
-        let (mut sender, mut receiver) = mpsc::channel::<DeviceListEvent>(10);
-        let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
-        tracked.insert(
-            tracked_device("Device1", 2).0,
-            tracked_device("Device1", 2).1,
-        );
-        tracked.insert(
-            tracked_device("Device2", 2).0,
-            tracked_device("Device2", 2).1,
-        );
-        let peripherals: Vec<btleplug::platform::Peripheral> = vec![];
-
-        announce_device_changes(&mut sender, &peripherals, &mut tracked).await;
-
-        sender.close_channel();
-
-        // Should receive 2 MeshRadioLost events
-        let mut lost_devices = Vec::new();
-        while let Ok(event) = receiver.try_recv() {
-            if let MeshRadioLost(name) = event {
-                lost_devices.push(name);
-            }
+    #[cfg(feature = "bluetooth")]
+    mod ble_tests {
+        use super::*;
+
+        #[test]
+        fn test_new_device_found() {
+            let current = devices(&["Device1"]);
+            let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
+
+            let (found, lost) = process_device_changes(&current, &mut tracked);
+
+            assert_eq!(found.len(), 1);
+            assert_eq!(found[0].0, DeviceIdentifier::from("Device1"));
+            assert!(lost.is_empty());
+            assert_eq!(
+                tracked
+                    .get(&DeviceIdentifier::from("Device1"))
+                    .map(|(c, _)| *c),
+                Some(0)
+            );
         }
 
-        assert_eq!(lost_devices.len(), 2);
-        assert!(lost_devices.contains(&DeviceIdentifier::from("Device1")));
-        assert!(lost_devices.contains(&DeviceIdentifier::from("Device2")));
-        assert!(tracked.is_empty());
-    }
+        #[test]
+        fn test_multiple_new_devices_found() {
+            let current = devices(&["Device1", "Device2", "Device3"]);
+            let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
 
-    #[tokio::test]
-    async fn test_announce_device_changes_mixed_tracked_states() {
-        let (mut sender, mut receiver) = mpsc::channel::<DeviceListEvent>(10);
-        let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
-        tracked.insert(
-            tracked_device("Device1", 0).0,
-            tracked_device("Device1", 0).1,
-        );
-        tracked.insert(
-            tracked_device("Device2", 1).0,
-            tracked_device("Device2", 1).1,
-        );
-        tracked.insert(
-            tracked_device("Device3", 2).0,
-            tracked_device("Device3", 2).1,
-        );
-        let peripherals: Vec<btleplug::platform::Peripheral> = vec![];
+            let (found, lost) = process_device_changes(&current, &mut tracked);
 
-        announce_device_changes(&mut sender, &peripherals, &mut tracked).await;
+            assert_eq!(found.len(), 3);
+            let found_names: Vec<_> = found.iter().map(|(name, _)| String::from(name)).collect();
+            assert!(found_names.contains(&"Device1".to_string()));
+            assert!(found_names.contains(&"Device2".to_string()));
+            assert!(found_names.contains(&"Device3".to_string()));
+            assert!(lost.is_empty());
+            assert_eq!(tracked.len(), 3);
+        }
 
-        sender.close_channel();
+        #[test]
+        fn test_no_devices() {
+            let current: HashMap<DeviceIdentifier, RadioType> = HashMap::new();
+            let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
 
-        // Should receive only 1 MeshRadioLost event for Device3
-        let event = receiver.try_recv().expect("Expected MeshRadioLost event");
-        assert!(matches!(event, MeshRadioLost(name) if name == DeviceIdentifier::from("Device3")));
+            let (found, lost) = process_device_changes(&current, &mut tracked);
 
-        // No more events
-        assert!(
-            receiver.try_recv().is_err(),
-            "Expected no more events but received one"
-        );
+            assert!(found.is_empty());
+            assert!(lost.is_empty());
+            assert!(tracked.is_empty());
+        }
 
-        // Device1 and Device2 should still be tracked
-        assert_eq!(
-            tracked
-                .get(&DeviceIdentifier::from("Device1"))
-                .map(|(c, _)| *c),
-            Some(1)
-        );
-        assert_eq!(
-            tracked
-                .get(&DeviceIdentifier::from("Device2"))
-                .map(|(c, _)| *c),
-            Some(2)
-        );
-        assert!(!tracked.contains_key(&DeviceIdentifier::from("Device3")));
-    }
+        // Test device still present
+        #[test]
+        fn test_device_still_present() {
+            let current = devices(&["Device1"]);
+            let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
+            tracked.insert(
+                tracked_device("Device1", 0).0,
+                tracked_device("Device1", 0).1,
+            );
 
-    // Tests for radio type handling in process_device_changes
+            let (found, lost) = process_device_changes(&current, &mut tracked);
 
-    #[cfg(feature = "meshtastic")]
-    fn devices_meshtastic(items: &[&str]) -> HashMap<DeviceIdentifier, RadioType> {
-        items
-            .iter()
-            .map(|s| (DeviceIdentifier::from(*s), RadioType::Meshtastic))
-            .collect()
-    }
+            assert!(found.is_empty());
+            assert!(lost.is_empty());
+            assert_eq!(
+                tracked
+                    .get(&DeviceIdentifier::from("Device1"))
+                    .map(|(c, _)| *c),
+                Some(0)
+            );
+        }
 
-    #[cfg(feature = "meshcore")]
-    fn devices_meshcore(items: &[&str]) -> HashMap<DeviceIdentifier, RadioType> {
-        items
-            .iter()
-            .map(|s| (DeviceIdentifier::from(*s), RadioType::MeshCore))
-            .collect()
-    }
+        #[test]
+        fn test_device_reappears_resets_count() {
+            let current = devices(&["Device1"]);
+            let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
+            tracked.insert(
+                tracked_device("Device1", 2).0,
+                tracked_device("Device1", 2).1,
+            );
 
-    #[cfg(feature = "meshtastic")]
-    #[test]
-    fn test_process_device_changes_preserves_meshtastic_radio_type() {
-        let current = devices_meshtastic(&["Device1"]);
-        let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
+            let (found, lost) = process_device_changes(&current, &mut tracked);
 
-        let (found, _) = process_device_changes(&current, &mut tracked);
+            assert!(found.is_empty());
+            assert!(lost.is_empty());
+            // Count should be reset to 0
+            assert_eq!(
+                tracked
+                    .get(&DeviceIdentifier::from("Device1"))
+                    .map(|(c, _)| *c),
+                Some(0)
+            );
+        }
 
-        assert_eq!(found.len(), 1);
-        assert_eq!(found[0].0, DeviceIdentifier::from("Device1"));
-        assert_eq!(found[0].1, RadioType::Meshtastic);
-        assert_eq!(
-            tracked
-                .get(&DeviceIdentifier::from("Device1"))
-                .map(|(_, rt)| *rt),
-            Some(RadioType::Meshtastic)
-        );
-    }
+        // Test device disappearing
+        #[test]
+        fn test_device_unseen_once() {
+            let current: HashMap<DeviceIdentifier, RadioType> = HashMap::new();
+            let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
+            tracked.insert(
+                tracked_device("Device1", 0).0,
+                tracked_device("Device1", 0).1,
+            );
 
-    #[cfg(feature = "meshcore")]
-    #[test]
-    fn test_process_device_changes_preserves_meshcore_radio_type() {
-        let current = devices_meshcore(&["Device1"]);
-        let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
+            let (found, lost) = process_device_changes(&current, &mut tracked);
 
-        let (found, _) = process_device_changes(&current, &mut tracked);
+            assert!(found.is_empty());
+            assert!(lost.is_empty()); // Not lost yet, only unseen once
+            assert_eq!(
+                tracked
+                    .get(&DeviceIdentifier::from("Device1"))
+                    .map(|(c, _)| *c),
+                Some(1)
+            );
+        }
 
-        assert_eq!(found.len(), 1);
-        assert_eq!(found[0].0, DeviceIdentifier::from("Device1"));
-        assert_eq!(found[0].1, RadioType::MeshCore);
-        assert_eq!(
-            tracked
-                .get(&DeviceIdentifier::from("Device1"))
-                .map(|(_, rt)| *rt),
-            Some(RadioType::MeshCore)
-        );
-    }
+        #[test]
+        fn test_device_unseen_twice() {
+            let current: HashMap<DeviceIdentifier, RadioType> = HashMap::new();
+            let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
+            tracked.insert(
+                tracked_device("Device1", 1).0,
+                tracked_device("Device1", 1).1,
+            );
 
-    #[cfg(all(feature = "meshtastic", feature = "meshcore"))]
-    #[test]
-    fn test_process_device_changes_mixed_radio_types() {
-        let mut current: HashMap<DeviceIdentifier, RadioType> = HashMap::new();
-        current.insert(
-            DeviceIdentifier::from("MeshtasticDevice"),
-            RadioType::Meshtastic,
-        );
-        current.insert(
-            DeviceIdentifier::from("MeshCoreDevice"),
-            RadioType::MeshCore,
-        );
+            let (found, lost) = process_device_changes(&current, &mut tracked);
 
-        let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
+            assert!(found.is_empty());
+            assert!(lost.is_empty()); // Not lost yet, only unseen twice
+            assert_eq!(
+                tracked
+                    .get(&DeviceIdentifier::from("Device1"))
+                    .map(|(c, _)| *c),
+                Some(2)
+            );
+        }
 
-        let (found, _) = process_device_changes(&current, &mut tracked);
+        #[test]
+        fn test_device_lost_after_three_unseen() {
+            let current: HashMap<DeviceIdentifier, RadioType> = HashMap::new();
+            let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
+            tracked.insert(
+                tracked_device("Device1", 2).0,
+                tracked_device("Device1", 2).1,
+            );
 
-        assert_eq!(found.len(), 2);
-        let meshtastic_found = found
-            .iter()
-            .find(|(name, _)| name == &DeviceIdentifier::from("MeshtasticDevice"))
-            .expect("MeshtasticDevice should be found");
-        let meshcore_found = found
-            .iter()
-            .find(|(name, _)| name == &DeviceIdentifier::from("MeshCoreDevice"))
-            .expect("MeshCoreDevice should be found");
+            let (found, lost) = process_device_changes(&current, &mut tracked);
 
-        assert_eq!(meshtastic_found.1, RadioType::Meshtastic);
-        assert_eq!(meshcore_found.1, RadioType::MeshCore);
-    }
+            assert!(found.is_empty());
+            assert_eq!(lost, vec![DeviceIdentifier::from("Device1")]);
+            // Device should be removed from tracking
+            assert!(!tracked.contains_key(&DeviceIdentifier::from("Device1")));
+        }
 
-    // Test detect_radio_type with multiple service UUIDs
-    #[cfg(feature = "meshtastic")]
-    #[test]
-    fn test_detect_radio_type_meshtastic_with_other_uuids() {
-        let other_uuid = Uuid::from_u128(0x12345678_1234_1234_1234_123456789abc);
-        let services = vec![other_uuid, MESHTASTIC_SERVICE_UUID];
-        assert_eq!(detect_radio_type(&services), Some(RadioType::Meshtastic));
-    }
+        #[test]
+        fn test_device_removed_from_tracking_after_lost() {
+            let current: HashMap<DeviceIdentifier, RadioType> = HashMap::new();
+            let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
+            tracked.insert(
+                tracked_device("Device1", 2).0,
+                tracked_device("Device1", 2).1,
+            );
 
-    #[cfg(feature = "meshcore")]
-    #[test]
-    fn test_detect_radio_type_meshcore_with_other_uuids() {
-        let other_uuid = Uuid::from_u128(0x12345678_1234_1234_1234_123456789abc);
-        let services = vec![other_uuid, MESHCORE_SERVICE_UUID];
-        assert_eq!(detect_radio_type(&services), Some(RadioType::MeshCore));
-    }
+            process_device_changes(&current, &mut tracked);
 
-    #[cfg(all(feature = "meshtastic", feature = "meshcore"))]
-    #[test]
-    fn test_detect_radio_type_both_services_meshtastic_first() {
-        // When both services are present, meshtastic takes priority (checked first)
-        let services = vec![MESHTASTIC_SERVICE_UUID, MESHCORE_SERVICE_UUID];
-        assert_eq!(detect_radio_type(&services), Some(RadioType::Meshtastic));
-    }
+            assert!(tracked.is_empty());
+        }
 
-    #[cfg(all(feature = "meshtastic", feature = "meshcore"))]
-    #[test]
-    fn test_detect_radio_type_both_services_meshcore_first() {
-        // Even when meshcore UUID is first, meshtastic still wins (due to check order)
-        let services = vec![MESHCORE_SERVICE_UUID, MESHTASTIC_SERVICE_UUID];
-        assert_eq!(detect_radio_type(&services), Some(RadioType::Meshtastic));
-    }
+        // Test mixed scenarios
+        #[test]
+        fn test_one_found_one_still_present() {
+            let current = devices(&["Device1", "Device2"]);
+            let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
+            tracked.insert(
+                tracked_device("Device1", 0).0,
+                tracked_device("Device1", 0).1,
+            );
 
-    #[test]
-    fn test_detect_radio_type_many_unknown_uuids() {
-        let services: Vec<Uuid> = (0..10)
-            .map(|i| Uuid::from_u128(0x10000000_0000_0000_0000_000000000000 + i))
-            .collect();
-        assert_eq!(detect_radio_type(&services), None);
-    }
+            let (found, lost) = process_device_changes(&current, &mut tracked);
 
-    #[cfg(feature = "meshtastic")]
-    // Test helper functions
-    #[test]
-    fn test_devices_helper_creates_correct_map() {
-        let result = devices(&["A", "B", "C"]);
-        assert_eq!(result.len(), 3);
-        assert!(result.contains_key(&DeviceIdentifier::from("A")));
-        assert!(result.contains_key(&DeviceIdentifier::from("B")));
-        assert!(result.contains_key(&DeviceIdentifier::from("C")));
-        assert_eq!(
-            result.get(&DeviceIdentifier::from("A")),
-            Some(&RadioType::Meshtastic)
-        );
-    }
+            assert_eq!(found.len(), 1);
+            assert_eq!(found[0].0, DeviceIdentifier::from("Device2"));
+            assert!(lost.is_empty());
+            assert_eq!(tracked.len(), 2);
+        }
 
-    #[test]
-    fn test_devices_helper_empty() {
-        let result = devices(&[]);
-        assert!(result.is_empty());
-    }
+        #[test]
+        fn test_one_found_one_disappearing() {
+            let current = devices(&["Device2"]);
+            let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
+            tracked.insert(
+                tracked_device("Device1", 0).0,
+                tracked_device("Device1", 0).1,
+            );
 
-    #[cfg(feature = "meshtastic")]
-    #[test]
-    fn test_tracked_device_helper() {
-        let (name, (count, radio_type)) = tracked_device("TestDevice", 5);
-        assert_eq!(name, DeviceIdentifier::from("TestDevice"));
-        assert_eq!(count, 5);
-        assert_eq!(radio_type, RadioType::Meshtastic);
-    }
+            let (found, lost) = process_device_changes(&current, &mut tracked);
 
-    // Test boundary conditions for unseen count
-    #[cfg(feature = "meshtastic")]
-    #[test]
-    fn test_unseen_count_boundary_at_2() {
-        let current: HashMap<DeviceIdentifier, RadioType> = HashMap::new();
-        let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
-        tracked.insert(
-            DeviceIdentifier::from("Device1"),
-            (2, RadioType::Meshtastic),
-        );
+            assert_eq!(found.len(), 1);
+            assert_eq!(found[0].0, DeviceIdentifier::from("Device2"));
+            assert!(lost.is_empty()); // Device1 not lost yet
+            assert_eq!(
+                tracked
+                    .get(&DeviceIdentifier::from("Device1"))
+                    .map(|(c, _)| *c),
+                Some(1)
+            );
+            assert_eq!(
+                tracked
+                    .get(&DeviceIdentifier::from("Device2"))
+                    .map(|(c, _)| *c),
+                Some(0)
+            );
+        }
 
-        let (_, lost) = process_device_changes(&current, &mut tracked);
+        #[test]
+        fn test_one_found_one_lost() {
+            let current = devices(&["Device2"]);
+            let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
+            tracked.insert(
+                tracked_device("Device1", 2).0,
+                tracked_device("Device1", 2).1,
+            );
 
-        // At count 2, after increment it becomes 3, which triggers loss
-        assert_eq!(lost.len(), 1);
-        assert!(lost.contains(&DeviceIdentifier::from("Device1")));
-    }
+            let (found, lost) = process_device_changes(&current, &mut tracked);
 
-    #[cfg(feature = "meshtastic")]
-    #[test]
-    fn test_unseen_count_boundary_at_1() {
-        let current: HashMap<DeviceIdentifier, RadioType> = HashMap::new();
-        let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
-        tracked.insert(
-            DeviceIdentifier::from("Device1"),
-            (1, RadioType::Meshtastic),
-        );
+            assert_eq!(found.len(), 1);
+            assert_eq!(found[0].0, DeviceIdentifier::from("Device2"));
+            assert_eq!(lost, vec![DeviceIdentifier::from("Device1")]);
+            assert!(!tracked.contains_key(&DeviceIdentifier::from("Device1")));
+            assert_eq!(
+                tracked
+                    .get(&DeviceIdentifier::from("Device2"))
+                    .map(|(c, _)| *c),
+                Some(0)
+            );
+        }
 
-        let (_, lost) = process_device_changes(&current, &mut tracked);
+        #[test]
+        fn test_multiple_devices_different_states() {
+            let current = devices(&["Device1", "Device4"]);
+            let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
+            tracked.insert(
+                tracked_device("Device1", 1).0,
+                tracked_device("Device1", 1).1,
+            );
+            tracked.insert(
+                tracked_device("Device2", 0).0,
+                tracked_device("Device2", 0).1,
+            );
+            tracked.insert(
+                tracked_device("Device3", 2).0,
+                tracked_device("Device3", 2).1,
+            );
 
-        // At count 1, after increment it becomes 2, not yet lost
-        assert!(lost.is_empty());
-        assert_eq!(
-            tracked
-                .get(&DeviceIdentifier::from("Device1"))
-                .map(|(c, _)| *c),
-            Some(2)
-        );
-    }
+            let (found, lost) = process_device_changes(&current, &mut tracked);
 
-    #[cfg(feature = "meshtastic")]
-    // Test that lost event includes correct device names
-    #[test]
-    fn test_lost_returns_correct_device_names() {
-        let current: HashMap<DeviceIdentifier, RadioType> = HashMap::new();
-        let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
-        tracked.insert(
-            DeviceIdentifier::from("UniqueDeviceName123"),
-            (2, RadioType::Meshtastic),
-        );
+            assert_eq!(found.len(), 1);
+            assert_eq!(found[0].0, DeviceIdentifier::from("Device4"));
+            assert_eq!(lost, vec![DeviceIdentifier::from("Device3")]);
+            assert_eq!(
+                tracked
+                    .get(&DeviceIdentifier::from("Device1"))
+                    .map(|(c, _)| *c),
+                Some(0)
+            ); // Reset
+            assert_eq!(
+                tracked
+                    .get(&DeviceIdentifier::from("Device2"))
+                    .map(|(c, _)| *c),
+                Some(1)
+            ); // Incremented
+            assert!(!tracked.contains_key(&DeviceIdentifier::from("Device3"))); // Removed
+            assert_eq!(
+                tracked
+                    .get(&DeviceIdentifier::from("Device4"))
+                    .map(|(c, _)| *c),
+                Some(0)
+            ); // New
+        }
 
-        let (_, lost) = process_device_changes(&current, &mut tracked);
+        // Test the full lifecycle
+        #[test]
+        fn test_device_full_lifecycle() {
+            let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
 
-        assert_eq!(lost, vec![DeviceIdentifier::from("UniqueDeviceName123")]);
-    }
+            // Cycle 1: Device appears
+            let current = devices(&["Device1"]);
+            let (found, lost) = process_device_changes(&current, &mut tracked);
+            assert_eq!(found.len(), 1);
+            assert_eq!(found[0].0, DeviceIdentifier::from("Device1"));
+            assert!(lost.is_empty());
+            assert_eq!(
+                tracked
+                    .get(&DeviceIdentifier::from("Device1"))
+                    .map(|(c, _)| *c),
+                Some(0)
+            );
 
-    #[cfg(feature = "meshtastic")]
-    // Test Unicode device names
-    #[test]
-    fn test_device_with_unicode_name() {
-        let mut current: HashMap<DeviceIdentifier, RadioType> = HashMap::new();
-        current.insert(
-            DeviceIdentifier::from("日本語デバイス"),
-            RadioType::Meshtastic,
-        );
-        current.insert(DeviceIdentifier::from("Устройство"), RadioType::Meshtastic);
-        current.insert(DeviceIdentifier::from("📱Device"), RadioType::Meshtastic);
+            // Cycle 2: Device still present
+            let (found, lost) = process_device_changes(&current, &mut tracked);
+            assert!(found.is_empty());
+            assert!(lost.is_empty());
+            assert_eq!(
+                tracked
+                    .get(&DeviceIdentifier::from("Device1"))
+                    .map(|(c, _)| *c),
+                Some(0)
+            );
 
-        let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
+            // Cycle 3: Device disappears (unseen 1)
+            let current: HashMap<DeviceIdentifier, RadioType> = HashMap::new();
+            let (found, lost) = process_device_changes(&current, &mut tracked);
+            assert!(found.is_empty());
+            assert!(lost.is_empty());
+            assert_eq!(
+                tracked
+                    .get(&DeviceIdentifier::from("Device1"))
+                    .map(|(c, _)| *c),
+                Some(1)
+            );
 
-        let (found, _) = process_device_changes(&current, &mut tracked);
+            // Cycle 4: Device still gone (unseen 2)
+            let (found, lost) = process_device_changes(&current, &mut tracked);
+            assert!(found.is_empty());
+            assert!(lost.is_empty());
+            assert_eq!(
+                tracked
+                    .get(&DeviceIdentifier::from("Device1"))
+                    .map(|(c, _)| *c),
+                Some(2)
+            );
 
-        assert_eq!(found.len(), 3);
-        assert!(tracked.contains_key(&DeviceIdentifier::from("日本語デバイス")));
-        assert!(tracked.contains_key(&DeviceIdentifier::from("Устройство")));
-        assert!(tracked.contains_key(&DeviceIdentifier::from("📱Device")));
-    }
+            // Cycle 5: Device still gone (unseen 3 - lost)
+            let (found, lost) = process_device_changes(&current, &mut tracked);
+            assert!(found.is_empty());
+            assert_eq!(lost, vec![DeviceIdentifier::from("Device1")]);
+            assert!(!tracked.contains_key(&DeviceIdentifier::from("Device1")));
+        }
 
-    #[cfg(feature = "meshtastic")]
-    // Test device with an empty name
-    #[test]
-    fn test_device_with_empty_name() {
-        let mut current: HashMap<DeviceIdentifier, RadioType> = HashMap::new();
-        current.insert(DeviceIdentifier::from(""), RadioType::Meshtastic);
+        #[test]
+        fn test_device_reappears_during_disappearing() {
+            let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
+            tracked.insert(
+                tracked_device("Device1", 2).0,
+                tracked_device("Device1", 2).1,
+            );
 
-        let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
+            // Device reappears just in time
+            let current = devices(&["Device1"]);
+            let (found, lost) = process_device_changes(&current, &mut tracked);
 
-        let (found, _) = process_device_changes(&current, &mut tracked);
+            assert!(found.is_empty()); // Not new, was tracked
+            assert!(lost.is_empty()); // Not lost, reappeared
+            assert_eq!(
+                tracked
+                    .get(&DeviceIdentifier::from("Device1"))
+                    .map(|(c, _)| *c),
+                Some(0)
+            ); // Count reset
+        }
 
-        assert_eq!(found.len(), 1);
-        assert_eq!(found[0].0, DeviceIdentifier::from(""));
-        assert!(tracked.contains_key(&DeviceIdentifier::from("")));
-    }
+        #[test]
+        fn test_lost_device_can_be_found_again() {
+            let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
 
-    #[cfg(feature = "meshtastic")]
-    // Test very long device name
-    #[test]
-    fn test_device_with_long_name() {
-        let long_name = DeviceIdentifier::from("A".repeat(1000));
-        let mut current: HashMap<DeviceIdentifier, RadioType> = HashMap::new();
-        current.insert(long_name.clone(), RadioType::Meshtastic);
+            // Device appears
+            let current = devices(&["Device1"]);
+            process_device_changes(&current, &mut tracked);
+            assert!(tracked.contains_key(&DeviceIdentifier::from("Device1")));
 
-        let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
+            // Device is lost after 3 cycles
+            let empty: HashMap<DeviceIdentifier, RadioType> = HashMap::new();
+            process_device_changes(&empty, &mut tracked); // unseen 1
+            process_device_changes(&empty, &mut tracked); // unseen 2
+            let (_, lost) = process_device_changes(&empty, &mut tracked); // unseen 3, lost
+            assert_eq!(lost, vec![DeviceIdentifier::from("Device1")]);
+            assert!(!tracked.contains_key(&DeviceIdentifier::from("Device1")));
 
-        let (found, _) = process_device_changes(&current, &mut tracked);
+            // Device reappears - should be found as new
+            let (found, _) = process_device_changes(&current, &mut tracked);
+            assert_eq!(found.len(), 1);
+            assert_eq!(found[0].0, DeviceIdentifier::from("Device1"));
+            assert_eq!(
+                tracked
+                    .get(&DeviceIdentifier::from("Device1"))
+                    .map(|(c, _)| *c),
+                Some(0)
+            );
+        }
 
-        assert_eq!(found.len(), 1);
-        assert_eq!(found[0].0, long_name);
-    }
+        // Edge cases
+        #[test]
+        fn test_empty_to_empty() {
+            let current: HashMap<DeviceIdentifier, RadioType> = HashMap::new();
+            let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
 
-    // Test rapid device cycling
-    #[test]
-    fn test_rapid_device_cycling() {
-        let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
+            let (found, lost) = process_device_changes(&current, &mut tracked);
 
-        // Device appears
-        let current = devices(&["Device1"]);
-        let (found, _) = process_device_changes(&current, &mut tracked);
-        assert_eq!(found.len(), 1);
+            assert!(found.is_empty());
+            assert!(lost.is_empty());
+            assert!(tracked.is_empty());
+        }
 
-        // Device disappears
-        let empty: HashMap<DeviceIdentifier, RadioType> = HashMap::new();
-        process_device_changes(&empty, &mut tracked);
-        process_device_changes(&empty, &mut tracked);
+        #[test]
+        fn test_device_with_special_characters() {
+            let current = devices(&["Device-1_test", "Device 2", "Device\t3"]);
+            let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
 
-        // Device reappears before being lost
-        let (found, lost) = process_device_changes(&current, &mut tracked);
-        assert!(found.is_empty()); // Not new, was still tracked
-        assert!(lost.is_empty()); // Not lost, count reset
-        assert_eq!(
-            tracked
-                .get(&DeviceIdentifier::from("Device1"))
-                .map(|(c, _)| *c),
-            Some(0)
-        );
-    }
+            let (found, _) = process_device_changes(&current, &mut tracked);
 
-    #[cfg(feature = "meshtastic")]
-    // Test many devices performance
-    #[test]
-    fn test_many_devices() {
-        let device_names: Vec<DeviceIdentifier> = (0..100)
-            .map(|i| DeviceIdentifier::from(format!("Device{}", i).as_str()))
-            .collect();
-        let current: HashMap<DeviceIdentifier, RadioType> = device_names
-            .iter()
-            .map(|s| (s.clone(), RadioType::Meshtastic))
-            .collect();
+            assert_eq!(found.len(), 3);
+            assert!(tracked.contains_key(&DeviceIdentifier::from("Device-1_test")));
+            assert!(tracked.contains_key(&DeviceIdentifier::from("Device 2")));
+            assert!(tracked.contains_key(&DeviceIdentifier::from("Device\t3")));
+        }
 
-        let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
+        #[test]
+        fn test_multiple_devices_lost_simultaneously() {
+            let current: HashMap<DeviceIdentifier, RadioType> = HashMap::new();
+            let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
+            tracked.insert(
+                tracked_device("Device1", 2).0,
+                tracked_device("Device1", 2).1,
+            );
+            tracked.insert(
+                tracked_device("Device2", 2).0,
+                tracked_device("Device2", 2).1,
+            );
+            tracked.insert(
+                tracked_device("Device3", 2).0,
+                tracked_device("Device3", 2).1,
+            );
 
-        let (found, lost) = process_device_changes(&current, &mut tracked);
+            let (found, lost) = process_device_changes(&current, &mut tracked);
 
-        assert_eq!(found.len(), 100);
-        assert!(lost.is_empty());
-        assert_eq!(tracked.len(), 100);
-    }
+            assert!(found.is_empty());
+            assert_eq!(lost.len(), 3);
+            assert!(lost.contains(&DeviceIdentifier::from("Device1")));
+            assert!(lost.contains(&DeviceIdentifier::from("Device2")));
+            assert!(lost.contains(&DeviceIdentifier::from("Device3")));
+            assert!(tracked.is_empty());
+        }
+
+        // Test MSH_SERVICE constant
+        #[cfg(feature = "meshtastic")]
+        #[test]
+        fn test_msh_service_uuid() {
+            assert_eq!(
+                MESHTASTIC_SERVICE_UUID,
+                Uuid::from_u128(0x6ba1b218_15a8_461f_9fa8_5dcae273eafd)
+            );
+        }
+
+        #[cfg(feature = "meshcore")]
+        #[test]
+        fn test_meshcore_service_uuid() {
+            assert_eq!(
+                MESHCORE_SERVICE_UUID,
+                Uuid::from_u128(0x6e400001_b5a3_f393_e0a9_e50e24dcca9e)
+            );
+        }
+
+        // Test detect_radio_type function
+        #[cfg(feature = "meshtastic")]
+        #[test]
+        fn test_detect_radio_type_meshtastic() {
+            let services = vec![MESHTASTIC_SERVICE_UUID];
+            assert_eq!(detect_radio_type(&services), Some(RadioType::Meshtastic));
+        }
+
+        #[cfg(feature = "meshcore")]
+        #[test]
+        fn test_detect_radio_type_meshcore() {
+            let services = vec![MESHCORE_SERVICE_UUID];
+            assert_eq!(detect_radio_type(&services), Some(RadioType::MeshCore));
+        }
+
+        #[test]
+        fn test_detect_radio_type_empty() {
+            let services: Vec<Uuid> = vec![];
+            // Should return default
+            assert_eq!(detect_radio_type(&services), None);
+        }
+
+        #[test]
+        fn test_detect_radio_type_unknown_uuid() {
+            let services = vec![Uuid::from_u128(0x12345678_1234_1234_1234_123456789abc)];
+            // Should return default
+            assert_eq!(detect_radio_type(&services), None);
+        }
+
+        // Async tests for announce_device_changes
+        use futures_channel::mpsc;
+
+        // Mock peripheral for testing - we can't easily implement Peripheral trait,
+        // but we can test with empty vectors
+        #[tokio::test]
+        async fn test_announce_device_changes_empty_peripherals_empty_tracked() {
+            let (mut sender, mut receiver) = mpsc::channel::<DeviceListEvent>(10);
+            let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
+            let peripherals: Vec<btleplug::platform::Peripheral> = vec![];
+
+            announce_device_changes(&mut sender, &peripherals, &mut tracked).await;
+
+            // Close the sender to signal no more messages
+            sender.close_channel();
+
+            // No events should be sent
+            assert!(
+                receiver.try_recv().is_err(),
+                "Expected no events but received one"
+            );
+            assert!(tracked.is_empty());
+        }
+
+        #[tokio::test]
+        async fn test_announce_device_changes_empty_peripherals_with_tracked_unseen_once() {
+            let (mut sender, mut receiver) = mpsc::channel::<DeviceListEvent>(10);
+            let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
+            tracked.insert(
+                tracked_device("Device1", 0).0,
+                tracked_device("Device1", 0).1,
+            );
+            let peripherals: Vec<btleplug::platform::Peripheral> = vec![];
+
+            announce_device_changes(&mut sender, &peripherals, &mut tracked).await;
+
+            sender.close_channel();
+
+            // No events should be sent (the device has only been unseen once)
+            assert!(
+                receiver.try_recv().is_err(),
+                "Expected no events but received one"
+            );
+            // Device should still be tracked with incremented count
+            assert_eq!(
+                tracked
+                    .get(&DeviceIdentifier::from("Device1"))
+                    .map(|(c, _)| *c),
+                Some(1)
+            );
+        }
+
+        #[tokio::test]
+        async fn test_announce_device_changes_empty_peripherals_device_lost() {
+            let (mut sender, mut receiver) = mpsc::channel::<DeviceListEvent>(10);
+            let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
+            tracked.insert(
+                tracked_device("Device1", 2).0,
+                tracked_device("Device1", 2).1,
+            );
+            let peripherals: Vec<btleplug::platform::Peripheral> = vec![];
+
+            announce_device_changes(&mut sender, &peripherals, &mut tracked).await;
+
+            sender.close_channel();
+
+            // Should receive MeshRadioLost event
+            let event = receiver.try_recv().expect("Expected MeshRadioLost event");
+            assert!(
+                matches!(event, MeshRadioLost(device_id) if device_id == DeviceIdentifier::from("Device1"))
+            );
+
+            // No more events
+            assert!(
+                receiver.try_recv().is_err(),
+                "Expected no more events but received one"
+            );
+
+            // Device should be removed from tracking
+            assert!(!tracked.contains_key(&DeviceIdentifier::from("Device1")));
+        }
+
+        #[tokio::test]
+        async fn test_announce_device_changes_multiple_devices_lost() {
+            let (mut sender, mut receiver) = mpsc::channel::<DeviceListEvent>(10);
+            let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
+            tracked.insert(
+                tracked_device("Device1", 2).0,
+                tracked_device("Device1", 2).1,
+            );
+            tracked.insert(
+                tracked_device("Device2", 2).0,
+                tracked_device("Device2", 2).1,
+            );
+            let peripherals: Vec<btleplug::platform::Peripheral> = vec![];
+
+            announce_device_changes(&mut sender, &peripherals, &mut tracked).await;
+
+            sender.close_channel();
+
+            // Should receive 2 MeshRadioLost events
+            let mut lost_devices = Vec::new();
+            while let Ok(event) = receiver.try_recv() {
+                if let MeshRadioLost(name) = event {
+                    lost_devices.push(name);
+                }
+            }
+
+            assert_eq!(lost_devices.len(), 2);
+            assert!(lost_devices.contains(&DeviceIdentifier::from("Device1")));
+            assert!(lost_devices.contains(&DeviceIdentifier::from("Device2")));
+            assert!(tracked.is_empty());
+        }
+
+        #[tokio::test]
+        async fn test_announce_device_changes_mixed_tracked_states() {
+            let (mut sender, mut receiver) = mpsc::channel::<DeviceListEvent>(10);
+            let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
+            tracked.insert(
+                tracked_device("Device1", 0).0,
+                tracked_device("Device1", 0).1,
+            );
+            tracked.insert(
+                tracked_device("Device2", 1).0,
+                tracked_device("Device2", 1).1,
+            );
+            tracked.insert(
+                tracked_device("Device3", 2).0,
+                tracked_device("Device3", 2).1,
+            );
+            let peripherals: Vec<btleplug::platform::Peripheral> = vec![];
+
+            announce_device_changes(&mut sender, &peripherals, &mut tracked).await;
+
+            sender.close_channel();
+
+            // Should receive only 1 MeshRadioLost event for Device3
+            let event = receiver.try_recv().expect("Expected MeshRadioLost event");
+            assert!(
+                matches!(event, MeshRadioLost(name) if name == DeviceIdentifier::from("Device3"))
+            );
+
+            // No more events
+            assert!(
+                receiver.try_recv().is_err(),
+                "Expected no more events but received one"
+            );
+
+            // Device1 and Device2 should still be tracked
+            assert_eq!(
+                tracked
+                    .get(&DeviceIdentifier::from("Device1"))
+                    .map(|(c, _)| *c),
+                Some(1)
+            );
+            assert_eq!(
+                tracked
+                    .get(&DeviceIdentifier::from("Device2"))
+                    .map(|(c, _)| *c),
+                Some(2)
+            );
+            assert!(!tracked.contains_key(&DeviceIdentifier::from("Device3")));
+        }
+
+        // Tests for radio type handling in process_device_changes
+
+        #[cfg(feature = "meshtastic")]
+        fn devices_meshtastic(items: &[&str]) -> HashMap<DeviceIdentifier, RadioType> {
+            items
+                .iter()
+                .map(|s| (DeviceIdentifier::from(*s), RadioType::Meshtastic))
+                .collect()
+        }
+
+        #[cfg(feature = "meshcore")]
+        fn devices_meshcore(items: &[&str]) -> HashMap<DeviceIdentifier, RadioType> {
+            items
+                .iter()
+                .map(|s| (DeviceIdentifier::from(*s), RadioType::MeshCore))
+                .collect()
+        }
+
+        #[cfg(feature = "meshtastic")]
+        #[test]
+        fn test_process_device_changes_preserves_meshtastic_radio_type() {
+            let current = devices_meshtastic(&["Device1"]);
+            let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
+
+            let (found, _) = process_device_changes(&current, &mut tracked);
+
+            assert_eq!(found.len(), 1);
+            assert_eq!(found[0].0, DeviceIdentifier::from("Device1"));
+            assert_eq!(found[0].1, RadioType::Meshtastic);
+            assert_eq!(
+                tracked
+                    .get(&DeviceIdentifier::from("Device1"))
+                    .map(|(_, rt)| *rt),
+                Some(RadioType::Meshtastic)
+            );
+        }
+
+        #[cfg(feature = "meshcore")]
+        #[test]
+        fn test_process_device_changes_preserves_meshcore_radio_type() {
+            let current = devices_meshcore(&["Device1"]);
+            let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
+
+            let (found, _) = process_device_changes(&current, &mut tracked);
+
+            assert_eq!(found.len(), 1);
+            assert_eq!(found[0].0, DeviceIdentifier::from("Device1"));
+            assert_eq!(found[0].1, RadioType::MeshCore);
+            assert_eq!(
+                tracked
+                    .get(&DeviceIdentifier::from("Device1"))
+                    .map(|(_, rt)| *rt),
+                Some(RadioType::MeshCore)
+            );
+        }
+
+        #[cfg(all(feature = "meshtastic", feature = "meshcore"))]
+        #[test]
+        fn test_process_device_changes_mixed_radio_types() {
+            let mut current: HashMap<DeviceIdentifier, RadioType> = HashMap::new();
+            current.insert(
+                DeviceIdentifier::from("MeshtasticDevice"),
+                RadioType::Meshtastic,
+            );
+            current.insert(
+                DeviceIdentifier::from("MeshCoreDevice"),
+                RadioType::MeshCore,
+            );
+
+            let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
+
+            let (found, _) = process_device_changes(&current, &mut tracked);
+
+            assert_eq!(found.len(), 2);
+            let meshtastic_found = found
+                .iter()
+                .find(|(name, _)| name == &DeviceIdentifier::from("MeshtasticDevice"))
+                .expect("MeshtasticDevice should be found");
+            let meshcore_found = found
+                .iter()
+                .find(|(name, _)| name == &DeviceIdentifier::from("MeshCoreDevice"))
+                .expect("MeshCoreDevice should be found");
+
+            assert_eq!(meshtastic_found.1, RadioType::Meshtastic);
+            assert_eq!(meshcore_found.1, RadioType::MeshCore);
+        }
+
+        // Test detect_radio_type with multiple service UUIDs
+        #[cfg(feature = "meshtastic")]
+        #[test]
+        fn test_detect_radio_type_meshtastic_with_other_uuids() {
+            let other_uuid = Uuid::from_u128(0x12345678_1234_1234_1234_123456789abc);
+            let services = vec![other_uuid, MESHTASTIC_SERVICE_UUID];
+            assert_eq!(detect_radio_type(&services), Some(RadioType::Meshtastic));
+        }
+
+        #[cfg(feature = "meshcore")]
+        #[test]
+        fn test_detect_radio_type_meshcore_with_other_uuids() {
+            let other_uuid = Uuid::from_u128(0x12345678_1234_1234_1234_123456789abc);
+            let services = vec![other_uuid, MESHCORE_SERVICE_UUID];
+            assert_eq!(detect_radio_type(&services), Some(RadioType::MeshCore));
+        }
+
+        #[cfg(all(feature = "meshtastic", feature = "meshcore"))]
+        #[test]
+        fn test_detect_radio_type_both_services_meshtastic_first() {
+            // When both services are present, meshtastic takes priority (checked first)
+            let services = vec![MESHTASTIC_SERVICE_UUID, MESHCORE_SERVICE_UUID];
+            assert_eq!(detect_radio_type(&services), Some(RadioType::Meshtastic));
+        }
+
+        #[cfg(all(feature = "meshtastic", feature = "meshcore"))]
+        #[test]
+        fn test_detect_radio_type_both_services_meshcore_first() {
+            // Even when meshcore UUID is first, meshtastic still wins (due to check order)
+            let services = vec![MESHCORE_SERVICE_UUID, MESHTASTIC_SERVICE_UUID];
+            assert_eq!(detect_radio_type(&services), Some(RadioType::Meshtastic));
+        }
+
+        #[test]
+        fn test_detect_radio_type_many_unknown_uuids() {
+            let services: Vec<Uuid> = (0..10)
+                .map(|i| Uuid::from_u128(0x10000000_0000_0000_0000_000000000000 + i))
+                .collect();
+            assert_eq!(detect_radio_type(&services), None);
+        }
+
+        #[cfg(feature = "meshtastic")]
+        // Test helper functions
+        #[test]
+        fn test_devices_helper_creates_correct_map() {
+            let result = devices(&["A", "B", "C"]);
+            assert_eq!(result.len(), 3);
+            assert!(result.contains_key(&DeviceIdentifier::from("A")));
+            assert!(result.contains_key(&DeviceIdentifier::from("B")));
+            assert!(result.contains_key(&DeviceIdentifier::from("C")));
+            assert_eq!(
+                result.get(&DeviceIdentifier::from("A")),
+                Some(&RadioType::Meshtastic)
+            );
+        }
+
+        #[test]
+        fn test_devices_helper_empty() {
+            let result = devices(&[]);
+            assert!(result.is_empty());
+        }
+
+        #[cfg(feature = "meshtastic")]
+        #[test]
+        fn test_tracked_device_helper() {
+            let (name, (count, radio_type)) = tracked_device("TestDevice", 5);
+            assert_eq!(name, DeviceIdentifier::from("TestDevice"));
+            assert_eq!(count, 5);
+            assert_eq!(radio_type, RadioType::Meshtastic);
+        }
+
+        // Test boundary conditions for unseen count
+        #[cfg(feature = "meshtastic")]
+        #[test]
+        fn test_unseen_count_boundary_at_2() {
+            let current: HashMap<DeviceIdentifier, RadioType> = HashMap::new();
+            let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
+            tracked.insert(
+                DeviceIdentifier::from("Device1"),
+                (2, RadioType::Meshtastic),
+            );
+
+            let (_, lost) = process_device_changes(&current, &mut tracked);
+
+            // At count 2, after increment it becomes 3, which triggers loss
+            assert_eq!(lost.len(), 1);
+            assert!(lost.contains(&DeviceIdentifier::from("Device1")));
+        }
+
+        #[cfg(feature = "meshtastic")]
+        #[test]
+        fn test_unseen_count_boundary_at_1() {
+            let current: HashMap<DeviceIdentifier, RadioType> = HashMap::new();
+            let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
+            tracked.insert(
+                DeviceIdentifier::from("Device1"),
+                (1, RadioType::Meshtastic),
+            );
+
+            let (_, lost) = process_device_changes(&current, &mut tracked);
+
+            // At count 1, after increment it becomes 2, not yet lost
+            assert!(lost.is_empty());
+            assert_eq!(
+                tracked
+                    .get(&DeviceIdentifier::from("Device1"))
+                    .map(|(c, _)| *c),
+                Some(2)
+            );
+        }
+
+        #[cfg(feature = "meshtastic")]
+        // Test that lost event includes correct device names
+        #[test]
+        fn test_lost_returns_correct_device_names() {
+            let current: HashMap<DeviceIdentifier, RadioType> = HashMap::new();
+            let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
+            tracked.insert(
+                DeviceIdentifier::from("UniqueDeviceName123"),
+                (2, RadioType::Meshtastic),
+            );
+
+            let (_, lost) = process_device_changes(&current, &mut tracked);
+
+            assert_eq!(lost, vec![DeviceIdentifier::from("UniqueDeviceName123")]);
+        }
+
+        #[cfg(feature = "meshtastic")]
+        // Test Unicode device names
+        #[test]
+        fn test_device_with_unicode_name() {
+            let mut current: HashMap<DeviceIdentifier, RadioType> = HashMap::new();
+            current.insert(
+                DeviceIdentifier::from("日本語デバイス"),
+                RadioType::Meshtastic,
+            );
+            current.insert(DeviceIdentifier::from("Устройство"), RadioType::Meshtastic);
+            current.insert(DeviceIdentifier::from("📱Device"), RadioType::Meshtastic);
+
+            let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
+
+            let (found, _) = process_device_changes(&current, &mut tracked);
+
+            assert_eq!(found.len(), 3);
+            assert!(tracked.contains_key(&DeviceIdentifier::from("日本語デバイス")));
+            assert!(tracked.contains_key(&DeviceIdentifier::from("Устройство")));
+            assert!(tracked.contains_key(&DeviceIdentifier::from("📱Device")));
+        }
+
+        #[cfg(feature = "meshtastic")]
+        // Test device with an empty name
+        #[test]
+        fn test_device_with_empty_name() {
+            let mut current: HashMap<DeviceIdentifier, RadioType> = HashMap::new();
+            current.insert(DeviceIdentifier::from(""), RadioType::Meshtastic);
+
+            let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
+
+            let (found, _) = process_device_changes(&current, &mut tracked);
+
+            assert_eq!(found.len(), 1);
+            assert_eq!(found[0].0, DeviceIdentifier::from(""));
+            assert!(tracked.contains_key(&DeviceIdentifier::from("")));
+        }
+
+        #[cfg(feature = "meshtastic")]
+        // Test very long device name
+        #[test]
+        fn test_device_with_long_name() {
+            let long_name = DeviceIdentifier::from("A".repeat(1000));
+            let mut current: HashMap<DeviceIdentifier, RadioType> = HashMap::new();
+            current.insert(long_name.clone(), RadioType::Meshtastic);
+
+            let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
+
+            let (found, _) = process_device_changes(&current, &mut tracked);
+
+            assert_eq!(found.len(), 1);
+            assert_eq!(found[0].0, long_name);
+        }
+
+        // Test rapid device cycling
+        #[test]
+        fn test_rapid_device_cycling() {
+            let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
+
+            // Device appears
+            let current = devices(&["Device1"]);
+            let (found, _) = process_device_changes(&current, &mut tracked);
+            assert_eq!(found.len(), 1);
+
+            // Device disappears
+            let empty: HashMap<DeviceIdentifier, RadioType> = HashMap::new();
+            process_device_changes(&empty, &mut tracked);
+            process_device_changes(&empty, &mut tracked);
+
+            // Device reappears before being lost
+            let (found, lost) = process_device_changes(&current, &mut tracked);
+            assert!(found.is_empty()); // Not new, was still tracked
+            assert!(lost.is_empty()); // Not lost, count reset
+            assert_eq!(
+                tracked
+                    .get(&DeviceIdentifier::from("Device1"))
+                    .map(|(c, _)| *c),
+                Some(0)
+            );
+        }
+
+        #[cfg(feature = "meshtastic")]
+        // Test many devices performance
+        #[test]
+        fn test_many_devices() {
+            let device_names: Vec<DeviceIdentifier> = (0..100)
+                .map(|i| DeviceIdentifier::from(format!("Device{}", i).as_str()))
+                .collect();
+            let current: HashMap<DeviceIdentifier, RadioType> = device_names
+                .iter()
+                .map(|s| (s.clone(), RadioType::Meshtastic))
+                .collect();
+
+            let mut tracked: HashMap<DeviceIdentifier, (i32, RadioType)> = HashMap::new();
+
+            let (found, lost) = process_device_changes(&current, &mut tracked);
+
+            assert_eq!(found.len(), 100);
+            assert!(lost.is_empty());
+            assert_eq!(tracked.len(), 100);
+        }
+    } // mod ble_tests
 }

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -1,7 +1,7 @@
 use crate::device::DeviceIdentifier;
 use crate::device_list::DeviceListEvent;
 use crate::device_list::DeviceListEvent::{
-    BLEMeshRadioFound, BLERadioLost, CriticalError, Error, Scanning,
+    CriticalError, Error, MeshRadioFound, MeshRadioLost, Scanning,
 };
 use crate::device_list::RadioType;
 #[cfg(feature = "meshcore")]
@@ -14,9 +14,17 @@ use futures::SinkExt;
 use futures_channel::mpsc::Sender;
 use iced::futures::Stream;
 use iced::stream;
+#[cfg(feature = "meshtastic")]
+use mdns_sd::{ServiceDaemon, ServiceEvent};
 use std::collections::HashMap;
+#[cfg(feature = "meshtastic")]
+use std::net::IpAddr;
 use std::time::Duration;
 use uuid::Uuid;
+
+/// mDNS service type advertised by Meshtastic devices for their TCP API (port 4403 by default).
+#[cfg(feature = "meshtastic")]
+const MESHTASTIC_MDNS_SERVICE: &str = "_meshtastic._tcp.local.";
 
 /// A stream of [DeviceListEvent] announcing the discovery or loss of devices via BLE
 pub fn ble_discovery() -> impl Stream<Item = DeviceListEvent> {
@@ -120,7 +128,7 @@ async fn announce_device_changes(
         // jonesy:allow(unknown) async state machine artifact
         #[allow(clippy::collapsible_if)]
         if let Ok(Some(properties)) = peripheral.properties().await {
-            let identifier = DeviceIdentifier {
+            let identifier = DeviceIdentifier::Ble {
                 name: properties.local_name,
                 mac: match properties.address.into_inner() {
                     DEFAULT_MAC => None,
@@ -140,16 +148,16 @@ async fn announce_device_changes(
     // Send lost events
     for device in lost {
         gui_sender
-            .send(BLERadioLost(device))
+            .send(MeshRadioLost(device))
             .await
-            .unwrap_or_else(|e| eprintln!("Discovery could not send BLERadioLost: {e}"));
+            .unwrap_or_else(|e| eprintln!("Discovery could not send MeshRadioLost: {e}"));
     }
 
     // Send found events with the appropriate radio type
     #[allow(unused_variables)]
     for (device, radio_type) in found {
         gui_sender
-            .send(BLEMeshRadioFound(device, radio_type))
+            .send(MeshRadioFound(device, radio_type))
             .await
             .unwrap_or_else(|e| eprintln!("Discovery could not send BLEMeshtasticRadioFound: {e}"));
     }
@@ -207,6 +215,87 @@ fn process_device_changes(
     }
 
     (found, lost)
+}
+
+/// A stream of [DeviceListEvent] announcing the discovery or loss of Meshtastic devices reachable
+/// over TCP on the local network. Devices advertise themselves via mDNS-SD as
+/// `_meshtastic._tcp.local.`.
+#[cfg(feature = "meshtastic")]
+pub fn mdns_discovery() -> impl Stream<Item = DeviceListEvent> {
+    stream::channel(
+        100,
+        move |mut gui_sender: Sender<DeviceListEvent>| async move {
+            let daemon = match ServiceDaemon::new() {
+                Ok(d) => d,
+                Err(e) => {
+                    let _ = gui_sender
+                        .send(Error(format!("mDNS daemon could not start: {e}")))
+                        .await;
+                    return;
+                }
+            };
+
+            let receiver = match daemon.browse(MESHTASTIC_MDNS_SERVICE) {
+                Ok(r) => r,
+                Err(e) => {
+                    let _ = gui_sender
+                        .send(Error(format!("mDNS browse failed: {e}")))
+                        .await;
+                    return;
+                }
+            };
+
+            // Track fullname → identifier so that ServiceRemoved events can be mapped back to
+            // the same identifier that was emitted on ServiceResolved.
+            let mut resolved: HashMap<String, DeviceIdentifier> = HashMap::new();
+
+            while let Ok(event) = receiver.recv_async().await {
+                match event {
+                    ServiceEvent::ServiceResolved(info) => {
+                        let Some(host) = info
+                            .get_addresses()
+                            .iter()
+                            .find_map(|addr| match addr {
+                                IpAddr::V4(v4) => Some(v4.to_string()),
+                                _ => None,
+                            })
+                            .or_else(|| {
+                                info.get_addresses()
+                                    .iter()
+                                    .next()
+                                    .map(|addr| addr.to_string())
+                            })
+                        else {
+                            continue;
+                        };
+                        let port = info.get_port();
+                        // Friendly name = the service instance label, e.g. "MyMeshy" from
+                        // "MyMeshy._meshtastic._tcp.local."
+                        let fullname = info.get_fullname().to_string();
+                        let name = fullname
+                            .strip_suffix(MESHTASTIC_MDNS_SERVICE)
+                            .and_then(|s| s.strip_suffix('.'))
+                            .map(|s| s.to_string());
+
+                        let identifier = DeviceIdentifier::Tcp { name, host, port };
+                        if resolved.insert(fullname, identifier.clone()).as_ref()
+                            != Some(&identifier)
+                        {
+                            let _ = gui_sender
+                                .send(MeshRadioFound(identifier, RadioType::Meshtastic))
+                                .await;
+                        }
+                    }
+                    ServiceEvent::ServiceRemoved(_, fullname) => {
+                        if let Some(identifier) = resolved.remove(&fullname) {
+                            let _ = gui_sender.send(MeshRadioLost(identifier)).await;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        },
+    )
 }
 
 #[cfg(test)]
@@ -785,10 +874,10 @@ mod tests {
 
         sender.close_channel();
 
-        // Should receive BLERadioLost event
-        let event = receiver.try_recv().expect("Expected BLERadioLost event");
+        // Should receive MeshRadioLost event
+        let event = receiver.try_recv().expect("Expected MeshRadioLost event");
         assert!(
-            matches!(event, BLERadioLost(device_id) if device_id == DeviceIdentifier::from("Device1"))
+            matches!(event, MeshRadioLost(device_id) if device_id == DeviceIdentifier::from("Device1"))
         );
 
         // No more events
@@ -819,10 +908,10 @@ mod tests {
 
         sender.close_channel();
 
-        // Should receive 2 BLERadioLost events
+        // Should receive 2 MeshRadioLost events
         let mut lost_devices = Vec::new();
         while let Ok(event) = receiver.try_recv() {
-            if let BLERadioLost(name) = event {
+            if let MeshRadioLost(name) = event {
                 lost_devices.push(name);
             }
         }
@@ -855,9 +944,9 @@ mod tests {
 
         sender.close_channel();
 
-        // Should receive only 1 BLERadioLost event for Device3
-        let event = receiver.try_recv().expect("Expected BLERadioLost event");
-        assert!(matches!(event, BLERadioLost(name) if name == DeviceIdentifier::from("Device3")));
+        // Should receive only 1 MeshRadioLost event for Device3
+        let event = receiver.try_recv().expect("Expected MeshRadioLost event");
+        assert!(matches!(event, MeshRadioLost(name) if name == DeviceIdentifier::from("Device3")));
 
         // No more events
         assert!(

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -338,7 +338,7 @@ mod tests {
         )
     }
 
-    #[cfg(feature = "bluetooth")]
+    #[cfg(all(feature = "bluetooth", feature = "meshtastic"))]
     mod ble_tests {
         use super::*;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,9 @@
 #[cfg(not(any(feature = "meshtastic", feature = "meshcore")))]
 compile_error!("At least one of 'meshtastic' or 'meshcore' features must be enabled");
 
+#[cfg(not(any(feature = "bluetooth", feature = "tcp")))]
+compile_error!("At least one of 'bluetooth' or 'tcp' features must be enabled");
+
 use crate::meshchat::MeshChat;
 use iced::window;
 

--- a/src/meshc/subscription.rs
+++ b/src/meshc/subscription.rs
@@ -270,7 +270,7 @@ async fn do_connect(ble_device: &DeviceIdentifier) -> meshcore_rs::Result<MeshCo
         #[cfg(not(windows))]
         MeshCore::ble_connect(&ble_device.name()),
         #[cfg(windows)]
-        MeshCore::ble_connect(&ble_device.mac()),
+        MeshCore::ble_connect(&ble_device.mac().unwrap_or_else(|| ble_device.name())),
     )
     // jonesy:allow(unknown) async state machine artifact
     .await

--- a/src/meshchat.rs
+++ b/src/meshchat.rs
@@ -18,13 +18,17 @@ use crate::device::DeviceMessage::DisconnectRequest;
 use crate::device::DeviceMessage::SubscriptionMessage;
 use crate::device::{Device, DeviceIdentifier};
 use crate::device_list::{DeviceList, DeviceListEvent, RadioType};
+#[cfg(feature = "bluetooth")]
 use crate::discovery::ble_discovery;
-#[cfg(feature = "meshtastic")]
+#[cfg(feature = "tcp")]
 use crate::discovery::mdns_discovery;
+#[cfg(feature = "meshcore")]
+use crate::meshc;
+#[cfg(feature = "meshtastic")]
+use crate::mesht;
 use crate::notification::{Notification, Notifications};
 use crate::styles::{modal_style, picker_header_style, tooltip_style};
 use crate::timestamp::TimeStamp;
-use crate::{meshc, mesht};
 use iced::font::Weight;
 use iced::keyboard::key;
 use iced::widget::{Column, center, container, mouse_area, opaque, operation, stack, text};
@@ -587,8 +591,9 @@ impl MeshChat {
     pub(crate) fn subscription(&self) -> Subscription<Message> {
         // jonesy:allow(misaligned_ptr) via alloc in subscription vec (misaligned_ptr)
         let subscriptions = vec![
+            #[cfg(feature = "bluetooth")]
             Subscription::run(ble_discovery).map(DeviceListViewEvent),
-            #[cfg(feature = "meshtastic")]
+            #[cfg(feature = "tcp")]
             Subscription::run(mdns_discovery).map(DeviceListViewEvent),
             #[cfg(feature = "meshtastic")]
             Subscription::run(mesht::subscription::subscribe)

--- a/src/meshchat.rs
+++ b/src/meshchat.rs
@@ -19,6 +19,8 @@ use crate::device::DeviceMessage::SubscriptionMessage;
 use crate::device::{Device, DeviceIdentifier};
 use crate::device_list::{DeviceList, DeviceListEvent, RadioType};
 use crate::discovery::ble_discovery;
+#[cfg(feature = "meshtastic")]
+use crate::discovery::mdns_discovery;
 use crate::notification::{Notification, Notifications};
 use crate::styles::{modal_style, picker_header_style, tooltip_style};
 use crate::timestamp::TimeStamp;
@@ -586,6 +588,8 @@ impl MeshChat {
         // jonesy:allow(misaligned_ptr) via alloc in subscription vec (misaligned_ptr)
         let subscriptions = vec![
             Subscription::run(ble_discovery).map(DeviceListViewEvent),
+            #[cfg(feature = "meshtastic")]
+            Subscription::run(mdns_discovery).map(DeviceListViewEvent),
             #[cfg(feature = "meshtastic")]
             Subscription::run(mesht::subscription::subscribe)
                 .map(|m| DeviceViewEvent(SubscriptionMessage(m))),

--- a/src/mesht/subscription.rs
+++ b/src/mesht/subscription.rs
@@ -20,6 +20,7 @@ use crate::timestamp::TimeStamp;
 use futures::SinkExt;
 use futures::executor::block_on;
 use iced::stream;
+use meshtastic::Message;
 use meshtastic::api::{ConnectedStreamApi, StreamApi};
 use meshtastic::errors::Error;
 use meshtastic::packet::{PacketReceiver, PacketRouter};
@@ -31,8 +32,8 @@ use meshtastic::protobufs::mesh_packet::PayloadVariant::Decoded;
 use meshtastic::protobufs::telemetry::Variant::DeviceMetrics;
 use meshtastic::protobufs::{FromRadio, MeshPacket, PortNum, Position, Telemetry, User};
 use meshtastic::types::NodeId;
+use meshtastic::utils;
 use meshtastic::utils::stream::BleId;
-use meshtastic::{Message, utils};
 use std::pin::Pin;
 use std::time::Duration;
 use tokio::sync::mpsc::channel;
@@ -592,56 +593,72 @@ async fn send_user(
         .await
 }
 
-/// Connect to a specific [BleDevice] and return a [PacketReceiver] that receives messages from the
-/// radio and a [ConnectedStreamApi] that can be used to send messages to the radio.
+/// Connect to a specific [DeviceIdentifier] and return a [PacketReceiver] that receives messages
+/// from the radio and a [ConnectedStreamApi] that can be used to send messages to the radio.
 async fn do_connect(
-    ble_device: &DeviceIdentifier,
+    device: &DeviceIdentifier,
 ) -> Result<(PacketReceiver, ConnectedStreamApi), Error> {
-    // On windows try and connect using MAC Address, on other platforms use the name
-    #[cfg(windows)]
-    let ble_id = BleId::from_mac_address(
-        ble_device
-            .mac
-            .ok_or_else(|| Error::StreamBuildError {
-                source: Box::new(std::io::Error::new(
-                    std::io::ErrorKind::InvalidInput,
-                    "Meshtastic subscription",
-                )),
-                description: "MAC address required on Windows".to_string(),
-            })?
-            .to_string()
-            .as_str(),
-    )?;
-    #[cfg(not(windows))]
-    let ble_id = if let Some(name) = &ble_device.name {
-        BleId::from_name(name)
-    } else if let Some(mac) = &ble_device.mac {
-        BleId::from_mac_address(mac.to_string().as_str())?
-    } else {
-        return Err(Error::StreamBuildError {
-            source: Box::new(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                "Meshtastic subscription",
-            )),
-            description: "No name or MAC address".to_string(),
-        });
-    };
-
-    let ble_stream = timeout(
-        Duration::from_secs(30),
-        utils::stream::build_ble_stream::<BleId>(ble_id, Duration::from_secs(10)),
-        // jonesy:allow(unknown) async state machine artifact
-    )
-    .await
-    .map_err(|_| Error::StreamBuildError {
-        source: Box::new(std::io::Error::new(
-            std::io::ErrorKind::TimedOut,
-            "Connect timed out",
-        )),
-        description: "Connect".to_string(),
-    })??;
     let stream_api = StreamApi::new();
-    let (packet_receiver, stream_api) = stream_api.connect(ble_stream).await;
+    let (packet_receiver, stream_api) = match device {
+        DeviceIdentifier::Tcp { host, port, .. } => {
+            let tcp_stream = timeout(
+                Duration::from_secs(30),
+                utils::stream::build_tcp_stream(format!("{host}:{port}")),
+            )
+            .await
+            .map_err(|_| Error::StreamBuildError {
+                source: Box::new(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "Connect timed out",
+                )),
+                description: "Connect".to_string(),
+            })??;
+            stream_api.connect(tcp_stream).await
+        }
+        DeviceIdentifier::Ble { name, mac } => {
+            // On windows try and connect using MAC Address, on other platforms use the name
+            #[cfg(windows)]
+            let ble_id = BleId::from_mac_address(
+                mac.ok_or_else(|| Error::StreamBuildError {
+                    source: Box::new(std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        "Meshtastic subscription",
+                    )),
+                    description: "MAC address required on Windows".to_string(),
+                })?
+                .to_string()
+                .as_str(),
+            )?;
+            #[cfg(not(windows))]
+            let ble_id = if let Some(name) = name {
+                BleId::from_name(name)
+            } else if let Some(mac) = mac {
+                BleId::from_mac_address(mac.to_string().as_str())?
+            } else {
+                return Err(Error::StreamBuildError {
+                    source: Box::new(std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        "Meshtastic subscription",
+                    )),
+                    description: "No name or MAC address".to_string(),
+                });
+            };
+
+            let ble_stream = timeout(
+                Duration::from_secs(30),
+                utils::stream::build_ble_stream::<BleId>(ble_id, Duration::from_secs(10)),
+            )
+            .await
+            .map_err(|_| Error::StreamBuildError {
+                source: Box::new(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "Connect timed out",
+                )),
+                description: "Connect".to_string(),
+            })??;
+            stream_api.connect(ble_stream).await
+        }
+    };
     let config_id = utils::generate_rand_id();
     let stream_api = stream_api.configure(config_id).await?;
     Ok((packet_receiver, stream_api))

--- a/src/mesht/subscription.rs
+++ b/src/mesht/subscription.rs
@@ -33,6 +33,7 @@ use meshtastic::protobufs::telemetry::Variant::DeviceMetrics;
 use meshtastic::protobufs::{FromRadio, MeshPacket, PortNum, Position, Telemetry, User};
 use meshtastic::types::NodeId;
 use meshtastic::utils;
+#[cfg(feature = "bluetooth")]
 use meshtastic::utils::stream::BleId;
 use std::pin::Pin;
 use std::time::Duration;
@@ -600,10 +601,16 @@ async fn do_connect(
 ) -> Result<(PacketReceiver, ConnectedStreamApi), Error> {
     let stream_api = StreamApi::new();
     let (packet_receiver, stream_api) = match device {
+        #[cfg(feature = "tcp")]
         DeviceIdentifier::Tcp { host, port, .. } => {
+            let endpoint = if host.contains(':') {
+                format!("[{host}]:{port}")
+            } else {
+                format!("{host}:{port}")
+            };
             let tcp_stream = timeout(
                 Duration::from_secs(30),
-                utils::stream::build_tcp_stream(format!("{host}:{port}")),
+                utils::stream::build_tcp_stream(endpoint),
             )
             .await
             .map_err(|_| Error::StreamBuildError {
@@ -615,8 +622,8 @@ async fn do_connect(
             })??;
             stream_api.connect(tcp_stream).await
         }
+        #[cfg(feature = "bluetooth")]
         DeviceIdentifier::Ble { name, mac } => {
-            // On windows try and connect using MAC Address, on other platforms use the name
             #[cfg(windows)]
             let ble_id = BleId::from_mac_address(
                 mac.ok_or_else(|| Error::StreamBuildError {


### PR DESCRIPTION
## Summary

Adds TCP connectivity to Meshtastic devices via mDNS discovery, building on #375 with substantial rework:

- **Feature gating**: New `bluetooth` and `tcp` features (both default-on) gate BLE and TCP code independently. `btleplug` and `mdns-sd` are now optional dependencies
- **CodeRabbit fixes**: All 7 review findings from #375 addressed — TCP name fallback, `mac()` return type, endpoint validation, IPv6 handling, mDNS address-change events, stable Rust refactor
- **Tests**: 11 new TCP tests covering parsing, serialization, round-trip, validation, IPv6
- **CI**: New `all-feature-combinations` job ensures all feature combos compile

Closes #374
Supersedes #375

## Test plan

- [x] `cargo fmt` — clean
- [x] `make clippy test` — 780 tests pass, no warnings
- [x] `make jonesy` — 0 panic points
- [x] `cargo check-all-features` — all feature combinations compile
- [x] `cargo test --no-default-features --features meshtastic,tcp` — TCP-only: 670 tests pass
- [x] `cargo test --no-default-features --features meshtastic,bluetooth` — BLE-only: compiles and passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)