### PR TITLE
Fix macOS CI: use stable lcov instead of HEAD

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -41,8 +41,6 @@ jobs:
       - name: Setup LCOV
         if: runner.os != 'Windows'
         uses: hrishikesh-kadam/setup-lcov@v1
-        with:
-          ref: HEAD
 
       - name: Install dependencies - Linux
         if: runner.os == 'Linux'


### PR DESCRIPTION
## Summary
- Remove `ref: HEAD` from the `hrishikesh-kadam/setup-lcov@v1` action so it installs the stable Homebrew lcov package
- The lcov HEAD build now requires `sphinx-build` for man pages, which isn't available on GH Actions runners, causing the macOS CI job to fail

## Test plan
- [ ] Verify macOS-15 CI job passes with stable lcov
- [ ] Verify Linux CI jobs still pass
- [ ] Verify coverage upload still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)